### PR TITLE
Remove -strict from make conformance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ $(BIN)/protovalidate-conformance: $(BIN) Makefile
 
 .PHONY: test
 test: generate ## Run all unit tests
-	bazel test --test_output=all //...
+	bazel test --test_output=errors //...
 
 .PHONY: generate
 generate: generate-license ## Regenerate code and license headers

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,12 +1,6 @@
 workspace(name = "com_github_bufbuild_protovalidate_cc")
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("//bazel:deps.bzl", "protovalidate_cc_dependencies")
-
-# local_repository(
-#     name = "com_google_cel_cpp",
-#     path = "../cel-cpp",
-# )
 
 protovalidate_cc_dependencies()
 


### PR DESCRIPTION
Once the new conformance tool is picked up, this passes the conformance tests.