### PR TITLE
Update readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ int main() {
   buf::validate::Validator validator = factory->NewValidator(&arena);
   buf::validate::Violations results = validator.Validate(transaction).value();
   if (results.violations_size() > 0) {
-    std::cout << "validation failed: " << results.DebugString() << std::endl;
+    std::cout << "validation failed" << std::endl;
   } else {
     std::cout << "validation succeeded" << std::endl;
   }


### PR DESCRIPTION
Updates readme to include namespace on validator construction...

```diff
+  buf::validate::Validator validator ...
```

I removed the `DebugString()` call on fail case because it doesnt exist, if someone has an idea on how to unpack the violations into an output string im all ears