### PR TITLE
Makefile: fix bazel -> $(BAZEL) for some targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,11 +35,11 @@ generate: generate-license ## Regenerate code and license headers
 
 .PHONY: test
 test: generate ## Run all unit tests
-	bazel test --test_output=errors //...
+	$(BAZEL) test --test_output=errors //...
 
 .PHONY: build
 build: ## Build the project
-	bazel build //...
+	$(BAZEL) build //...
 
 .PHONY: conformance
 conformance: $(BIN)/protovalidate-conformance


### PR DESCRIPTION
Relatively minor issue: some targets directly invoke `bazel` instead of using the `$(BAZEL)` variable. The upshot of this is that e.g. `make BAZEL=bazelisk` does not work as expected as some calls will not use `bazelisk` as expected.