### PR TITLE
Add macOS testing to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,8 +12,11 @@ permissions:
   contents: read
 jobs:
   test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     name: Unit tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Cache
         uses: actions/cache@v3
@@ -24,6 +27,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+      - name: Install Make
+        run: choco install make
+        if: runner.os == 'Windows'
       - name: Install go
         uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
Platform coverage in CI is valuable for C++ since the toolchains are so variable. This PR should ensure nobody accidentally breaks macOS support.

Windows does not currently work due to cel-cpp issues. I don't think we can put any priority on patching that right now. I think MSVC testing would go a long way to attest that changes are more properly portable, versus GCC and Clang which are fairly similar. Hopefully, we can eventually rectify this. The necessary workflow change is already present in this PR, so once `cel-cpp` is fixed we just need to add `windows-latest` to the matrix. Some day.

This PR is one I worked on a long time ago, but got stalled on. I rebased it and cleaned it up since I think it is valuable enough to merge.