### PR TITLE
Implement predefined field constraints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ COPYRIGHT_YEARS := 2023
 LICENSE_IGNORE := -e internal/testdata/
 LICENSE_HEADER_VERSION := 0294fdbe1ce8649ebaf5e87e8cdd588e33730bbb
 # NOTE: Keep this version in sync with the version in `/bazel/deps.bzl`.
-PROTOVALIDATE_VERSION ?= v0.7.1
+PROTOVALIDATE_VERSION ?= v0.8.1
 
 # Set to use a different compiler. For example, `GO=go1.18rc1 make test`.
 GO ?= go

--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -65,10 +65,10 @@ _dependencies = {
     },
     # NOTE: Keep Version in sync with `/Makefile`.
     "com_github_bufbuild_protovalidate": {
-        "sha256": "ccb3952c38397d2cb53fe841af66b05fc012dd17fa754cbe35d9abb547cdf92d",
-        "strip_prefix": "protovalidate-0.7.1",
+        "sha256": "c637c8cbaf71b6dc38171e47c2c736581b4cfef385984083561480367659d14f",
+        "strip_prefix": "protovalidate-0.8.1",
         "urls": [
-            "https://github.com/bufbuild/protovalidate/archive/v0.7.1.tar.gz",
+            "https://github.com/bufbuild/protovalidate/archive/v0.8.1.tar.gz",
         ],
     },
 }

--- a/buf/validate/conformance/runner.cc
+++ b/buf/validate/conformance/runner.cc
@@ -20,8 +20,7 @@
 namespace buf::validate::conformance {
 
 harness::TestConformanceResponse TestRunner::runTest(
-    const harness::TestConformanceRequest& request,
-    const google::protobuf::DescriptorPool* descriptorPool) {
+    const harness::TestConformanceRequest& request) {
   harness::TestConformanceResponse response;
   for (const auto& tc : request.cases()) {
     auto& result = response.mutable_results()->operator[](tc.first);
@@ -32,7 +31,7 @@ harness::TestConformanceResponse TestRunner::runTest(
       *result.mutable_unexpected_error() = "could not parse type url " + dyn.type_url();
       continue;
     }
-    const auto* desc = descriptorPool->FindMessageTypeByName(dyn.type_url().substr(pos + 1));
+    const auto* desc = descriptorPool_->FindMessageTypeByName(dyn.type_url().substr(pos + 1));
     if (desc == nullptr) {
       *result.mutable_unexpected_error() = "could not find descriptor for type " + dyn.type_url();
     } else {

--- a/buf/validate/conformance/runner.h
+++ b/buf/validate/conformance/runner.h
@@ -22,7 +22,9 @@ namespace buf::validate::conformance {
 
 class TestRunner {
  public:
-  explicit TestRunner(const google::protobuf::DescriptorPool* descriptorPool)
+  explicit TestRunner(
+      const google::protobuf::DescriptorPool* descriptorPool =
+          google::protobuf::DescriptorPool::generated_pool())
       : descriptorPool_(descriptorPool), validatorFactory_(ValidatorFactory::New().value()) {
     validatorFactory_->SetMessageFactory(&messageFactory_, descriptorPool_);
   }

--- a/buf/validate/conformance/runner.h
+++ b/buf/validate/conformance/runner.h
@@ -22,17 +22,19 @@ namespace buf::validate::conformance {
 
 class TestRunner {
  public:
-  explicit TestRunner() : validatorFactory_(ValidatorFactory::New().value()) {}
+  explicit TestRunner(const google::protobuf::DescriptorPool* descriptorPool)
+      : descriptorPool_(descriptorPool), validatorFactory_(ValidatorFactory::New().value()) {
+    validatorFactory_->SetMessageFactory(&messageFactory_, descriptorPool_);
+  }
 
-  harness::TestConformanceResponse runTest(
-      const harness::TestConformanceRequest& request,
-      const google::protobuf::DescriptorPool* descriptorPool);
+  harness::TestConformanceResponse runTest(const harness::TestConformanceRequest& request);
   harness::TestResult runTestCase(
       const google::protobuf::Descriptor* desc, const google::protobuf::Any& dyn);
   harness::TestResult runTestCase(const google::protobuf::Message& message);
 
  private:
   google::protobuf::DynamicMessageFactory messageFactory_;
+  const google::protobuf::DescriptorPool* descriptorPool_;
   std::unique_ptr<ValidatorFactory> validatorFactory_;
   google::protobuf::Arena arena_;
 };

--- a/buf/validate/conformance/runner.h
+++ b/buf/validate/conformance/runner.h
@@ -27,6 +27,7 @@ class TestRunner {
           google::protobuf::DescriptorPool::generated_pool())
       : descriptorPool_(descriptorPool), validatorFactory_(ValidatorFactory::New().value()) {
     validatorFactory_->SetMessageFactory(&messageFactory_, descriptorPool_);
+    validatorFactory_->SetAllowUnknownFields(false);
   }
 
   harness::TestConformanceResponse runTest(const harness::TestConformanceRequest& request);

--- a/buf/validate/conformance/runner_main.cc
+++ b/buf/validate/conformance/runner_main.cc
@@ -16,14 +16,15 @@
 #include "buf/validate/conformance/runner.h"
 
 int main(int argc, char** argv) {
-  google::protobuf::DescriptorPool descriptorPool;
-  buf::validate::conformance::TestRunner runner;
+  google::protobuf::DescriptorPool descriptorPool{
+      google::protobuf::DescriptorPool::generated_pool()};
   buf::validate::conformance::harness::TestConformanceRequest request;
   request.ParseFromIstream(&std::cin);
   for (const auto& file : request.fdset().file()) {
     descriptorPool.BuildFile(file);
   }
-  auto response = runner.runTest(request, &descriptorPool);
+  buf::validate::conformance::TestRunner runner{&descriptorPool};
+  auto response = runner.runTest(request);
   response.SerializeToOstream(&std::cout);
   return 0;
 }

--- a/buf/validate/internal/BUILD.bazel
+++ b/buf/validate/internal/BUILD.bazel
@@ -23,7 +23,11 @@ cc_library(
         "@com_google_cel_cpp//eval/public:activation",
         "@com_google_cel_cpp//eval/public:cel_expression",
         "@com_google_cel_cpp//eval/public/structs:cel_proto_wrapper",
+        "@com_google_cel_cpp//eval/public/containers:field_access",
+        "@com_google_cel_cpp//eval/public/containers:field_backed_list_impl",
+        "@com_google_cel_cpp//eval/public/containers:field_backed_map_impl",
         "@com_google_cel_cpp//parser",
+        "@com_google_cel_cpp//base:value"
     ],
 )
 
@@ -44,7 +48,17 @@ cc_library(
     deps = [
         "@com_google_absl//absl/status",
         "@com_google_protobuf//:protobuf",
+        ":message_factory",
     ],
+)
+
+cc_library(
+    name = "message_factory",
+    srcs = ["message_factory.cc"],
+    hdrs = ["message_factory.h"],
+    deps = [
+        "@com_google_protobuf//:protobuf",
+    ]
 )
 
 cc_library(
@@ -53,6 +67,7 @@ cc_library(
     hdrs = ["message_rules.h"],
     deps = [
         ":field_rules",
+        ":message_factory",
         "@com_github_bufbuild_protovalidate//proto/protovalidate/buf/validate:validate_proto_cc",
         "@com_google_absl//absl/status",
         "@com_google_cel_cpp//eval/public:cel_expression",

--- a/buf/validate/internal/cel_constraint_rules.h
+++ b/buf/validate/internal/cel_constraint_rules.h
@@ -28,6 +28,7 @@ namespace buf::validate::internal {
 struct CompiledConstraint {
   buf::validate::Constraint constraint;
   std::unique_ptr<google::api::expr::runtime::CelExpression> expr;
+  const google::protobuf::FieldDescriptor* rule;
 };
 
 // An abstract base class for constraint with rules that are compiled into CEL expressions.
@@ -38,12 +39,15 @@ class CelConstraintRules : public ConstraintRules {
   using Base::Base;
 
   absl::Status Add(
-      google::api::expr::runtime::CelExpressionBuilder& builder, Constraint constraint);
+      google::api::expr::runtime::CelExpressionBuilder& builder,
+      Constraint constraint,
+      const google::protobuf::FieldDescriptor* rule);
   absl::Status Add(
       google::api::expr::runtime::CelExpressionBuilder& builder,
       std::string_view id,
       std::string_view message,
-      std::string_view expression);
+      std::string_view expression,
+      const google::protobuf::FieldDescriptor* rule);
   [[nodiscard]] const std::vector<CompiledConstraint>& getExprs() const { return exprs_; }
 
   // Validate all the cel rules given the activation that already has 'this' bound.

--- a/buf/validate/internal/cel_constraint_rules.h
+++ b/buf/validate/internal/cel_constraint_rules.h
@@ -16,7 +16,7 @@
 
 #include <string_view>
 
-#include "buf/validate/expression.pb.h"
+#include "buf/validate/validate.pb.h"
 #include "buf/validate/internal/constraint_rules.h"
 #include "eval/public/activation.h"
 #include "eval/public/cel_expression.h"

--- a/buf/validate/internal/cel_rules.h
+++ b/buf/validate/internal/cel_rules.h
@@ -32,7 +32,7 @@ absl::Status BuildCelRules(
     CelConstraintRules& result) {
   // Look for constraints on the set fields.
   std::vector<const google::protobuf::FieldDescriptor*> fields;
-  google::protobuf::Message* reparsedRules;
+  google::protobuf::Message* reparsedRules{};
   if (messageFactory) {
     reparsedRules = messageFactory->messageFactory()
                         ->GetPrototype(messageFactory->descriptorPool()->FindMessageTypeByName(

--- a/buf/validate/internal/cel_rules.h
+++ b/buf/validate/internal/cel_rules.h
@@ -60,10 +60,10 @@ absl::Status BuildCelRules(
     R::GetReflection()->ListFields(rules, &fields);
   }
   for (const auto* field : fields) {
-    if (!field->options().HasExtension(buf::validate::priv::field)) {
+    if (!field->options().HasExtension(buf::validate::predefined)) {
       continue;
     }
-    const auto& fieldLvl = field->options().GetExtension(buf::validate::priv::field);
+    const auto& fieldLvl = field->options().GetExtension(buf::validate::predefined);
     for (const auto& constraint : fieldLvl.cel()) {
       auto status = result.Add(
           builder, constraint.id(), constraint.message(), constraint.expression(), field);

--- a/buf/validate/internal/constraint_rules.h
+++ b/buf/validate/internal/constraint_rules.h
@@ -15,7 +15,7 @@
 #pragma once
 
 #include "absl/status/status.h"
-#include "buf/validate/expression.pb.h"
+#include "buf/validate/validate.pb.h"
 #include "eval/public/cel_value.h"
 #include "google/protobuf/arena.h"
 #include "google/protobuf/message.h"

--- a/buf/validate/internal/constraints.cc
+++ b/buf/validate/internal/constraints.cc
@@ -16,8 +16,6 @@
 
 #include "absl/status/statusor.h"
 #include "buf/validate/internal/extra_func.h"
-#include "buf/validate/priv/private.pb.h"
-#include "buf/validate/validate.pb.h"
 #include "eval/public/builtin_func_registrar.h"
 #include "eval/public/cel_expr_builder_factory.h"
 #include "eval/public/cel_value.h"
@@ -25,8 +23,6 @@
 #include "eval/public/containers/field_backed_list_impl.h"
 #include "eval/public/containers/field_backed_map_impl.h"
 #include "eval/public/structs/cel_proto_wrapper.h"
-#include "google/protobuf/any.pb.h"
-#include "google/protobuf/descriptor.pb.h"
 #include "google/protobuf/dynamic_message.h"
 #include "google/protobuf/util/message_differencer.h"
 

--- a/buf/validate/internal/constraints_test.cc
+++ b/buf/validate/internal/constraints_test.cc
@@ -48,7 +48,7 @@ class ExpressionTest : public testing::Test {
     constraint.set_expression(std::move(expr));
     constraint.set_message(std::move(message));
     constraint.set_id(std::move(id));
-    return constraints_->Add(*builder_, constraint);
+    return constraints_->Add(*builder_, constraint, nullptr);
   }
 
   absl::Status Validate(

--- a/buf/validate/internal/field_rules.cc
+++ b/buf/validate/internal/field_rules.cc
@@ -19,6 +19,7 @@
 
 namespace buf::validate::internal {
 absl::StatusOr<std::unique_ptr<FieldConstraintRules>> NewFieldRules(
+    std::unique_ptr<MessageFactory>& messageFactory,
     google::protobuf::Arena* arena,
     google::api::expr::runtime::CelExpressionBuilder& builder,
     const google::protobuf::FieldDescriptor* field,
@@ -30,6 +31,7 @@ absl::StatusOr<std::unique_ptr<FieldConstraintRules>> NewFieldRules(
   switch (fieldLvl.type_case()) {
     case FieldConstraints::kBool:
       rules_or = NewScalarFieldRules(
+          messageFactory,
           arena,
           builder,
           field,
@@ -40,6 +42,7 @@ absl::StatusOr<std::unique_ptr<FieldConstraintRules>> NewFieldRules(
       break;
     case FieldConstraints::kFloat:
       rules_or = NewScalarFieldRules(
+          messageFactory,
           arena,
           builder,
           field,
@@ -50,6 +53,7 @@ absl::StatusOr<std::unique_ptr<FieldConstraintRules>> NewFieldRules(
       break;
     case FieldConstraints::kDouble:
       rules_or = NewScalarFieldRules(
+          messageFactory,
           arena,
           builder,
           field,
@@ -60,6 +64,7 @@ absl::StatusOr<std::unique_ptr<FieldConstraintRules>> NewFieldRules(
       break;
     case FieldConstraints::kInt32:
       rules_or = NewScalarFieldRules(
+          messageFactory,
           arena,
           builder,
           field,
@@ -70,6 +75,7 @@ absl::StatusOr<std::unique_ptr<FieldConstraintRules>> NewFieldRules(
       break;
     case FieldConstraints::kInt64:
       rules_or = NewScalarFieldRules(
+          messageFactory,
           arena,
           builder,
           field,
@@ -80,6 +86,7 @@ absl::StatusOr<std::unique_ptr<FieldConstraintRules>> NewFieldRules(
       break;
     case FieldConstraints::kUint32:
       rules_or = NewScalarFieldRules(
+          messageFactory,
           arena,
           builder,
           field,
@@ -90,6 +97,7 @@ absl::StatusOr<std::unique_ptr<FieldConstraintRules>> NewFieldRules(
       break;
     case FieldConstraints::kUint64:
       rules_or = NewScalarFieldRules(
+          messageFactory,
           arena,
           builder,
           field,
@@ -100,6 +108,7 @@ absl::StatusOr<std::unique_ptr<FieldConstraintRules>> NewFieldRules(
       break;
     case FieldConstraints::kSint32:
       rules_or = NewScalarFieldRules(
+          messageFactory,
           arena,
           builder,
           field,
@@ -109,6 +118,7 @@ absl::StatusOr<std::unique_ptr<FieldConstraintRules>> NewFieldRules(
       break;
     case FieldConstraints::kSint64:
       rules_or = NewScalarFieldRules(
+          messageFactory,
           arena,
           builder,
           field,
@@ -118,6 +128,7 @@ absl::StatusOr<std::unique_ptr<FieldConstraintRules>> NewFieldRules(
       break;
     case FieldConstraints::kFixed32:
       rules_or = NewScalarFieldRules(
+          messageFactory,
           arena,
           builder,
           field,
@@ -127,6 +138,7 @@ absl::StatusOr<std::unique_ptr<FieldConstraintRules>> NewFieldRules(
       break;
     case FieldConstraints::kFixed64:
       rules_or = NewScalarFieldRules(
+          messageFactory,
           arena,
           builder,
           field,
@@ -136,6 +148,7 @@ absl::StatusOr<std::unique_ptr<FieldConstraintRules>> NewFieldRules(
       break;
     case FieldConstraints::kSfixed32:
       rules_or = NewScalarFieldRules(
+          messageFactory,
           arena,
           builder,
           field,
@@ -145,6 +158,7 @@ absl::StatusOr<std::unique_ptr<FieldConstraintRules>> NewFieldRules(
       break;
     case FieldConstraints::kSfixed64:
       rules_or = NewScalarFieldRules(
+          messageFactory,
           arena,
           builder,
           field,
@@ -154,6 +168,7 @@ absl::StatusOr<std::unique_ptr<FieldConstraintRules>> NewFieldRules(
       break;
     case FieldConstraints::kString:
       rules_or = NewScalarFieldRules(
+          messageFactory,
           arena,
           builder,
           field,
@@ -164,6 +179,7 @@ absl::StatusOr<std::unique_ptr<FieldConstraintRules>> NewFieldRules(
       break;
     case FieldConstraints::kBytes:
       rules_or = NewScalarFieldRules(
+          messageFactory,
           arena,
           builder,
           field,
@@ -176,6 +192,7 @@ absl::StatusOr<std::unique_ptr<FieldConstraintRules>> NewFieldRules(
       rules_or = std::make_unique<EnumConstraintRules>(field, fieldLvl);
       auto status = BuildScalarFieldRules(
           *rules_or.value(),
+          messageFactory,
           arena,
           builder,
           field,
@@ -194,7 +211,7 @@ absl::StatusOr<std::unique_ptr<FieldConstraintRules>> NewFieldRules(
         return absl::InvalidArgumentError("duration field validator on non-duration field");
       } else {
         auto result = std::make_unique<FieldConstraintRules>(field, fieldLvl);
-        auto status = BuildCelRules(arena, builder, fieldLvl.duration(), *result);
+        auto status = BuildCelRules(messageFactory, arena, builder, fieldLvl.duration(), *result);
         if (!status.ok()) {
           rules_or = status;
         } else {
@@ -209,7 +226,7 @@ absl::StatusOr<std::unique_ptr<FieldConstraintRules>> NewFieldRules(
         return absl::InvalidArgumentError("timestamp field validator on non-timestamp field");
       } else {
         auto result = std::make_unique<FieldConstraintRules>(field, fieldLvl);
-        auto status = BuildCelRules(arena, builder, fieldLvl.timestamp(), *result);
+        auto status = BuildCelRules(messageFactory, arena, builder, fieldLvl.timestamp(), *result);
         if (!status.ok()) {
           rules_or = status;
         } else {
@@ -225,14 +242,15 @@ absl::StatusOr<std::unique_ptr<FieldConstraintRules>> NewFieldRules(
       } else {
         std::unique_ptr<FieldConstraintRules> items;
         if (fieldLvl.repeated().has_items()) {
-          auto items_or = NewFieldRules(arena, builder, field, fieldLvl.repeated().items());
+          auto items_or =
+              NewFieldRules(messageFactory, arena, builder, field, fieldLvl.repeated().items());
           if (!items_or.ok()) {
             return items_or.status();
           }
           items = std::move(items_or).value();
         }
         auto result = std::make_unique<RepeatedConstraintRules>(field, fieldLvl, std::move(items));
-        auto status = BuildCelRules(arena, builder, fieldLvl.repeated(), *result);
+        auto status = BuildCelRules(messageFactory, arena, builder, fieldLvl.repeated(), *result);
         if (!status.ok()) {
           rules_or = status;
         } else {
@@ -244,19 +262,23 @@ absl::StatusOr<std::unique_ptr<FieldConstraintRules>> NewFieldRules(
       if (!field->is_map()) {
         return absl::InvalidArgumentError("map field validator on non-map field");
       } else {
-        auto keyRulesOr =
-            NewFieldRules(arena, builder, field->message_type()->field(0), fieldLvl.map().keys());
+        auto keyRulesOr = NewFieldRules(
+            messageFactory, arena, builder, field->message_type()->field(0), fieldLvl.map().keys());
         if (!keyRulesOr.ok()) {
           return keyRulesOr.status();
         }
-        auto valueRulesOr =
-            NewFieldRules(arena, builder, field->message_type()->field(1), fieldLvl.map().values());
+        auto valueRulesOr = NewFieldRules(
+            messageFactory,
+            arena,
+            builder,
+            field->message_type()->field(1),
+            fieldLvl.map().values());
         if (!valueRulesOr.ok()) {
           return valueRulesOr.status();
         }
         auto result = std::make_unique<MapConstraintRules>(
             field, fieldLvl, std::move(keyRulesOr).value(), std::move(valueRulesOr).value());
-        auto status = BuildCelRules(arena, builder, fieldLvl.map(), *result);
+        auto status = BuildCelRules(messageFactory, arena, builder, fieldLvl.map(), *result);
         if (!status.ok()) {
           rules_or = status;
         } else {
@@ -270,7 +292,7 @@ absl::StatusOr<std::unique_ptr<FieldConstraintRules>> NewFieldRules(
         return absl::InvalidArgumentError("any field validator on non-any field");
       } else {
         auto result = std::make_unique<FieldConstraintRules>(field, fieldLvl, &fieldLvl.any());
-        auto status = BuildCelRules(arena, builder, fieldLvl.any(), *result);
+        auto status = BuildCelRules(messageFactory, arena, builder, fieldLvl.any(), *result);
         if (!status.ok()) {
           rules_or = status;
         } else {
@@ -287,7 +309,7 @@ absl::StatusOr<std::unique_ptr<FieldConstraintRules>> NewFieldRules(
   }
   if (rules_or.ok()) {
     for (const auto& constraint : fieldLvl.cel()) {
-      auto status = rules_or.value()->Add(builder, constraint);
+      auto status = rules_or.value()->Add(builder, constraint, nullptr);
       if (!status.ok()) {
         return status;
       }

--- a/buf/validate/internal/field_rules.h
+++ b/buf/validate/internal/field_rules.h
@@ -26,6 +26,7 @@ template <typename R>
 absl::Status BuildScalarFieldRules(
     FieldConstraintRules& result,
     std::unique_ptr<MessageFactory>& messageFactory,
+    bool allowUnknownFields,
     google::protobuf::Arena* arena,
     google::api::expr::runtime::CelExpressionBuilder& builder,
     const google::protobuf::FieldDescriptor* field,
@@ -48,12 +49,13 @@ absl::Status BuildScalarFieldRules(
           google::protobuf::FieldDescriptor::TypeName(expectedType)));
     }
   }
-  return BuildCelRules(messageFactory, arena, builder, rules, result);
+  return BuildCelRules(messageFactory, allowUnknownFields, arena, builder, rules, result);
 }
 
 template <typename R>
 absl::StatusOr<std::unique_ptr<FieldConstraintRules>> NewScalarFieldRules(
     std::unique_ptr<MessageFactory>& messageFactory,
+    bool allowUnknownFields,
     google::protobuf::Arena* arena,
     google::api::expr::runtime::CelExpressionBuilder& builder,
     const google::protobuf::FieldDescriptor* field,
@@ -63,7 +65,16 @@ absl::StatusOr<std::unique_ptr<FieldConstraintRules>> NewScalarFieldRules(
     std::string_view wrapperName = "") {
   auto result = std::make_unique<FieldConstraintRules>(field, fieldLvl);
   auto status = BuildScalarFieldRules(
-      *result, messageFactory, arena, builder, field, fieldLvl, rules, expectedType, wrapperName);
+      *result,
+      messageFactory,
+      allowUnknownFields,
+      arena,
+      builder,
+      field,
+      fieldLvl,
+      rules,
+      expectedType,
+      wrapperName);
   if (!status.ok()) {
     return status;
   }
@@ -72,6 +83,7 @@ absl::StatusOr<std::unique_ptr<FieldConstraintRules>> NewScalarFieldRules(
 
 absl::StatusOr<std::unique_ptr<FieldConstraintRules>> NewFieldRules(
     std::unique_ptr<MessageFactory>& messageFactory,
+    bool allowUnknownFields,
     google::protobuf::Arena* arena,
     google::api::expr::runtime::CelExpressionBuilder& builder,
     const google::protobuf::FieldDescriptor* field,

--- a/buf/validate/internal/field_rules.h
+++ b/buf/validate/internal/field_rules.h
@@ -25,6 +25,7 @@ namespace buf::validate::internal {
 template <typename R>
 absl::Status BuildScalarFieldRules(
     FieldConstraintRules& result,
+    std::unique_ptr<MessageFactory>& messageFactory,
     google::protobuf::Arena* arena,
     google::api::expr::runtime::CelExpressionBuilder& builder,
     const google::protobuf::FieldDescriptor* field,
@@ -47,11 +48,12 @@ absl::Status BuildScalarFieldRules(
           google::protobuf::FieldDescriptor::TypeName(expectedType)));
     }
   }
-  return BuildCelRules(arena, builder, rules, result);
+  return BuildCelRules(messageFactory, arena, builder, rules, result);
 }
 
 template <typename R>
 absl::StatusOr<std::unique_ptr<FieldConstraintRules>> NewScalarFieldRules(
+    std::unique_ptr<MessageFactory>& messageFactory,
     google::protobuf::Arena* arena,
     google::api::expr::runtime::CelExpressionBuilder& builder,
     const google::protobuf::FieldDescriptor* field,
@@ -61,7 +63,7 @@ absl::StatusOr<std::unique_ptr<FieldConstraintRules>> NewScalarFieldRules(
     std::string_view wrapperName = "") {
   auto result = std::make_unique<FieldConstraintRules>(field, fieldLvl);
   auto status = BuildScalarFieldRules(
-      *result, arena, builder, field, fieldLvl, rules, expectedType, wrapperName);
+      *result, messageFactory, arena, builder, field, fieldLvl, rules, expectedType, wrapperName);
   if (!status.ok()) {
     return status;
   }
@@ -69,6 +71,7 @@ absl::StatusOr<std::unique_ptr<FieldConstraintRules>> NewScalarFieldRules(
 }
 
 absl::StatusOr<std::unique_ptr<FieldConstraintRules>> NewFieldRules(
+    std::unique_ptr<MessageFactory>& messageFactory,
     google::protobuf::Arena* arena,
     google::api::expr::runtime::CelExpressionBuilder& builder,
     const google::protobuf::FieldDescriptor* field,

--- a/buf/validate/internal/message_factory.cc
+++ b/buf/validate/internal/message_factory.cc
@@ -1,0 +1,31 @@
+// Copyright 2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "buf/validate/internal/message_factory.h"
+
+namespace buf::validate::internal {
+
+bool Reparse(
+    MessageFactory& messageFactory,
+    const google::protobuf::Message& from,
+    google::protobuf::Message* to) {
+  std::string serialized;
+  from.SerializeToString(&serialized);
+  google::protobuf::io::CodedInputStream input(
+      reinterpret_cast<const uint8_t*>(serialized.c_str()), static_cast<int>(serialized.size()));
+  input.SetExtensionRegistry(messageFactory.descriptorPool(), messageFactory.messageFactory());
+  return to->ParseFromCodedStream(&input);
+}
+
+} // namespace buf::validate::internal

--- a/buf/validate/internal/message_factory.h
+++ b/buf/validate/internal/message_factory.h
@@ -1,0 +1,43 @@
+// Copyright 2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "google/protobuf/descriptor.h"
+#include "google/protobuf/message.h"
+
+namespace buf::validate::internal {
+
+struct MessageFactory {
+ public:
+  MessageFactory(
+      google::protobuf::MessageFactory* messageFactory,
+      const google::protobuf::DescriptorPool* descriptorPool)
+      : messageFactory_(messageFactory), descriptorPool_(descriptorPool) {}
+
+  google::protobuf::MessageFactory* messageFactory() { return messageFactory_; }
+
+  const google::protobuf::DescriptorPool* descriptorPool() { return descriptorPool_; }
+
+ private:
+  google::protobuf::MessageFactory* messageFactory_;
+  const google::protobuf::DescriptorPool* descriptorPool_;
+};
+
+bool Reparse(
+    MessageFactory& messageFactory,
+    const google::protobuf::Message& from,
+    google::protobuf::Message* to);
+
+} // namespace buf::validate::internal

--- a/buf/validate/internal/message_rules.cc
+++ b/buf/validate/internal/message_rules.cc
@@ -32,6 +32,7 @@ absl::StatusOr<std::unique_ptr<MessageConstraintRules>> BuildMessageRules(
 
 Constraints NewMessageConstraints(
     std::unique_ptr<MessageFactory>& messageFactory,
+    bool allowUnknownFields,
     google::protobuf::Arena* arena,
     google::api::expr::runtime::CelExpressionBuilder& builder,
     const google::protobuf::Descriptor* descriptor) {
@@ -54,7 +55,8 @@ Constraints NewMessageConstraints(
       continue;
     }
     const auto& fieldLvl = field->options().GetExtension(buf::validate::field);
-    auto rules_or = NewFieldRules(messageFactory, arena, builder, field, fieldLvl);
+    auto rules_or =
+        NewFieldRules(messageFactory, allowUnknownFields, arena, builder, field, fieldLvl);
     if (!rules_or.ok()) {
       return rules_or.status();
     }

--- a/buf/validate/internal/message_rules.cc
+++ b/buf/validate/internal/message_rules.cc
@@ -23,7 +23,7 @@ absl::StatusOr<std::unique_ptr<MessageConstraintRules>> BuildMessageRules(
     const MessageConstraints& constraints) {
   auto result = std::make_unique<MessageConstraintRules>();
   for (const auto& constraint : constraints.cel()) {
-    if (auto status = result->Add(builder, constraint); !status.ok()) {
+    if (auto status = result->Add(builder, constraint, nullptr); !status.ok()) {
       return status;
     }
   }
@@ -31,6 +31,7 @@ absl::StatusOr<std::unique_ptr<MessageConstraintRules>> BuildMessageRules(
 }
 
 Constraints NewMessageConstraints(
+    std::unique_ptr<MessageFactory>& messageFactory,
     google::protobuf::Arena* arena,
     google::api::expr::runtime::CelExpressionBuilder& builder,
     const google::protobuf::Descriptor* descriptor) {
@@ -53,7 +54,7 @@ Constraints NewMessageConstraints(
       continue;
     }
     const auto& fieldLvl = field->options().GetExtension(buf::validate::field);
-    auto rules_or = NewFieldRules(arena, builder, field, fieldLvl);
+    auto rules_or = NewFieldRules(messageFactory, arena, builder, field, fieldLvl);
     if (!rules_or.ok()) {
       return rules_or.status();
     }

--- a/buf/validate/internal/message_rules.h
+++ b/buf/validate/internal/message_rules.h
@@ -16,6 +16,7 @@
 
 #include "absl/status/statusor.h"
 #include "buf/validate/internal/constraints.h"
+#include "buf/validate/internal/message_factory.h"
 #include "buf/validate/validate.pb.h"
 #include "eval/public/cel_expression.h"
 #include "google/protobuf/arena.h"
@@ -26,6 +27,7 @@ namespace buf::validate::internal {
 using Constraints = absl::StatusOr<std::vector<std::unique_ptr<ConstraintRules>>>;
 
 Constraints NewMessageConstraints(
+    std::unique_ptr<MessageFactory>& messageFactory,
     google::protobuf::Arena* arena,
     google::api::expr::runtime::CelExpressionBuilder& builder,
     const google::protobuf::Descriptor* descriptor);

--- a/buf/validate/internal/message_rules.h
+++ b/buf/validate/internal/message_rules.h
@@ -28,6 +28,7 @@ using Constraints = absl::StatusOr<std::vector<std::unique_ptr<ConstraintRules>>
 
 Constraints NewMessageConstraints(
     std::unique_ptr<MessageFactory>& messageFactory,
+    bool allowUnknownFields,
     google::protobuf::Arena* arena,
     google::api::expr::runtime::CelExpressionBuilder& builder,
     const google::protobuf::Descriptor* descriptor);

--- a/buf/validate/validator.cc
+++ b/buf/validate/validator.cc
@@ -141,7 +141,7 @@ absl::Status ValidatorFactory::Add(const google::protobuf::Descriptor* desc) {
     auto status =
         constraints_
             .emplace(
-                desc, internal::NewMessageConstraints(messageFactory_, &arena_, *builder_, desc))
+                desc, internal::NewMessageConstraints(messageFactory_, allowUnknownFields_, &arena_, *builder_, desc))
             .first->second.status();
     if (!status.ok()) {
       return status;
@@ -179,7 +179,7 @@ const internal::Constraints* ValidatorFactory::GetMessageConstraints(
   }
   return &constraints_
               .emplace(
-                  desc, internal::NewMessageConstraints(messageFactory_, &arena_, *builder_, desc))
+                  desc, internal::NewMessageConstraints(messageFactory_, allowUnknownFields_, &arena_, *builder_, desc))
               .first->second;
 }
 

--- a/buf/validate/validator.cc
+++ b/buf/validate/validator.cc
@@ -46,12 +46,13 @@ absl::Status Validator::ValidateFields(
     }
     if (field->options().HasExtension(validate::field)) {
       const auto& fieldExt = field->options().GetExtension(validate::field);
-      if (fieldExt.ignore() == IGNORE_ALWAYS ||
-          fieldExt.skipped() ||
-          (fieldExt.has_repeated() && (fieldExt.repeated().items().ignore() == IGNORE_ALWAYS ||
-                                       fieldExt.repeated().items().skipped())) ||
-          (fieldExt.has_map() && (fieldExt.map().values().ignore() == IGNORE_ALWAYS ||
-                                  fieldExt.map().values().skipped()))) {
+      if (fieldExt.ignore() == IGNORE_ALWAYS || fieldExt.skipped() ||
+          (fieldExt.has_repeated() &&
+           (fieldExt.repeated().items().ignore() == IGNORE_ALWAYS ||
+            fieldExt.repeated().items().skipped())) ||
+          (fieldExt.has_map() &&
+           (fieldExt.map().values().ignore() == IGNORE_ALWAYS ||
+            fieldExt.map().values().skipped()))) {
         continue;
       }
     }
@@ -138,7 +139,9 @@ absl::Status ValidatorFactory::Add(const google::protobuf::Descriptor* desc) {
       return iter->second.status();
     }
     auto status =
-        constraints_.emplace(desc, internal::NewMessageConstraints(&arena_, *builder_, desc))
+        constraints_
+            .emplace(
+                desc, internal::NewMessageConstraints(messageFactory_, &arena_, *builder_, desc))
             .first->second.status();
     if (!status.ok()) {
       return status;
@@ -174,7 +177,9 @@ const internal::Constraints* ValidatorFactory::GetMessageConstraints(
   if (iter != constraints_.end()) {
     return &iter->second;
   }
-  return &constraints_.emplace(desc, internal::NewMessageConstraints(&arena_, *builder_, desc))
+  return &constraints_
+              .emplace(
+                  desc, internal::NewMessageConstraints(messageFactory_, &arena_, *builder_, desc))
               .first->second;
 }
 

--- a/buf/validate/validator.h
+++ b/buf/validate/validator.h
@@ -20,6 +20,7 @@
 #include "buf/validate/expression.pb.h"
 #include "buf/validate/internal/constraints.h"
 #include "buf/validate/internal/message_rules.h"
+#include "buf/validate/internal/message_factory.h"
 #include "eval/public/cel_expression.h"
 #include "google/protobuf/message.h"
 
@@ -94,10 +95,18 @@ class ValidatorFactory {
     disableLazyLoading_ = disable;
   }
 
+  /// Set message factory and descriptor pool. This is used for re-parsing unknown fields.
+  /// The provided messageFactory and descriptorPool must outlive the ValidatorFactory.
+  void SetMessageFactory(google::protobuf::MessageFactory *messageFactory,
+                         const google::protobuf::DescriptorPool *descriptorPool) {
+    messageFactory_ = std::make_unique<internal::MessageFactory>(messageFactory, descriptorPool);
+  }
+
  private:
   friend class Validator;
   google::protobuf::Arena arena_;
   absl::Mutex mutex_;
+  std::unique_ptr<internal::MessageFactory> messageFactory_;
   absl::flat_hash_map<const google::protobuf::Descriptor*, internal::Constraints> constraints_
       ABSL_GUARDED_BY(mutex_);
   std::unique_ptr<google::api::expr::runtime::CelExpressionBuilder> builder_

--- a/buf/validate/validator.h
+++ b/buf/validate/validator.h
@@ -102,11 +102,17 @@ class ValidatorFactory {
     messageFactory_ = std::make_unique<internal::MessageFactory>(messageFactory, descriptorPool);
   }
 
+  /// Set whether or not unknown constraint fields will be tolerated. Defaults to false.
+  void SetAllowUnknownFields(bool allowUnknownFields) {
+    allowUnknownFields_ = allowUnknownFields;
+  }
+
  private:
   friend class Validator;
   google::protobuf::Arena arena_;
   absl::Mutex mutex_;
   std::unique_ptr<internal::MessageFactory> messageFactory_;
+  bool allowUnknownFields_;
   absl::flat_hash_map<const google::protobuf::Descriptor*, internal::Constraints> constraints_
       ABSL_GUARDED_BY(mutex_);
   std::unique_ptr<google::api::expr::runtime::CelExpressionBuilder> builder_

--- a/buf/validate/validator.h
+++ b/buf/validate/validator.h
@@ -17,7 +17,7 @@
 #include <memory>
 #include <string_view>
 
-#include "buf/validate/expression.pb.h"
+#include "buf/validate/validate.pb.h"
 #include "buf/validate/internal/constraints.h"
 #include "buf/validate/internal/message_rules.h"
 #include "buf/validate/internal/message_factory.h"


### PR DESCRIPTION
Like protovalidate-go and protovalidate-java, we need to adjust the code to handle dynamic descriptor sets more robustly, since we need to jump between resolving the protovalidate standard rules and the predefined rule extensions.  This necessitates adding a couple of additions to the API surface, namely `ValidatorFactory::SetMessageFactory` and `ValidatorFactory::SetAllowUnknownFields`, which controls instantiation of unknown dynamic types and whether or not to ignore unresolved rules, respectively. Like other protovalidate runtimes, we will default to failing compilation when unknown predefined rules are encountered. This should not break existing users but will prevent silent incorrect behavior.

TODO:
- [x] Skip reparse when there are no empty fields&mdash;this way we can avoid pessimizing the common case
- [x] Add an option to fail when unknown rule fields are unable to be resolved.
- [x] Update for protobuf changes in https://github.com/bufbuild/protovalidate/pull/246.

This will depend on https://github.com/bufbuild/protovalidate/pull/246.