### PR TITLE
Add field and rule value to violations

### DIFF
--- a/buf/validate/conformance/runner.cc
+++ b/buf/validate/conformance/runner.cc
@@ -69,7 +69,7 @@ harness::TestResult TestRunner::runTestCase(const google::protobuf::Message& mes
         break;
     }
   } else if (violations_or.value().violations_size() > 0) {
-    *result.mutable_validation_error() = std::move(violations_or).value();
+    *result.mutable_validation_error() = violations_or->proto();
   } else {
     result.set_success(true);
   }

--- a/buf/validate/internal/BUILD.bazel
+++ b/buf/validate/internal/BUILD.bazel
@@ -32,10 +32,22 @@ cc_library(
 )
 
 cc_library(
+    name = "proto_field",
+    hdrs = ["proto_field.h"],
+    deps = [
+        "@com_github_bufbuild_protovalidate//proto/protovalidate/buf/validate:validate_proto_cc",
+        "@com_google_absl//absl/status",
+        "@com_google_cel_cpp//eval/public:cel_value",
+        "@com_google_protobuf//:protobuf",
+    ],
+)
+
+cc_library(
     name = "constraint_rules",
     hdrs = ["constraint_rules.h"],
     deps = [
         "@com_github_bufbuild_protovalidate//proto/protovalidate/buf/validate:validate_proto_cc",
+        ":proto_field",
         "@com_google_absl//absl/status",
         "@com_google_cel_cpp//eval/public:cel_value",
         "@com_google_protobuf//:protobuf",

--- a/buf/validate/internal/constraint_rules.h
+++ b/buf/validate/internal/constraint_rules.h
@@ -15,12 +15,38 @@
 #pragma once
 
 #include "absl/status/status.h"
+#include "absl/strings/escaping.h"
 #include "buf/validate/validate.pb.h"
+#include "buf/validate/internal/proto_field.h"
 #include "eval/public/cel_value.h"
 #include "google/protobuf/arena.h"
 #include "google/protobuf/message.h"
 
 namespace buf::validate::internal {
+inline std::string fieldPathString(const FieldPath &path);
+
+/// ConstraintViolation is a wrapper for the protobuf Violation that provides additional in-memory
+/// information, specifically, references to the in-memory values for the field and rule.
+class ConstraintViolation {
+  friend struct ConstraintContext;
+
+ public:
+  ConstraintViolation(
+      Violation proto,
+      const absl::optional<ProtoField>& fieldValue,
+      const absl::optional<ProtoField>& ruleValue)
+      : proto_{std::move(proto)}, fieldValue_{fieldValue}, ruleValue_{ruleValue} {}
+
+  [[nodiscard]] const Violation& proto() const { return proto_; }
+  [[nodiscard]] absl::optional<ProtoField> field_value() const { return fieldValue_; }
+  [[nodiscard]] absl::optional<ProtoField> rule_value() const { return ruleValue_; }
+
+ private:
+  Violation proto_;
+  absl::optional<ProtoField> fieldValue_;
+  absl::optional<ProtoField> ruleValue_;
+};
+
 struct ConstraintContext {
   ConstraintContext() : failFast(false), arena(nullptr) {}
   ConstraintContext(const ConstraintContext&) = delete;
@@ -28,24 +54,56 @@ struct ConstraintContext {
 
   bool failFast;
   google::protobuf::Arena* arena;
-  Violations violations;
+  std::vector<ConstraintViolation> violations;
 
   [[nodiscard]] bool shouldReturn(const absl::Status status) {
-    return !status.ok() || (failFast && violations.violations_size() > 0);
+    return !status.ok() || (failFast && !violations.empty());
   }
 
   void appendFieldPathElement(const FieldPathElement &element, int start) {
-    for (int i = start; i < violations.violations_size(); i++) {
-      auto* violation = violations.mutable_violations(i);
-      *violation->mutable_field()->mutable_elements()->Add() = element;
+    for (int i = start; i < violations.size(); i++) {
+      *violations[i].proto_.mutable_field()->mutable_elements()->Add() = element;
     }
   }
 
   void appendRulePathElement(std::initializer_list<FieldPathElement> suffix, int start) {
-    for (int i = start; i < violations.violations_size(); i++) {
-      auto* violation = violations.mutable_violations(i);
-      auto* elements = violation->mutable_rule()->mutable_elements();
+    for (int i = start; i < violations.size(); i++) {
+      auto* elements = violations[i].proto_.mutable_rule()->mutable_elements();
       std::copy(suffix.begin(), suffix.end(), RepeatedPtrFieldBackInserter(elements));
+    }
+  }
+
+  void setFieldValue(ProtoField field, int start) {
+    for (int i = start; i < violations.size(); i++) {
+      violations[i].fieldValue_ = field;
+    }
+  }
+
+  void setRuleValue(ProtoField rule, int start) {
+    for (int i = start; i < violations.size(); i++) {
+      violations[i].ruleValue_ = rule;
+    }
+  }
+
+  void setForKey(int start) {
+    for (int i = start; i < violations.size(); i++) {
+      violations[i].proto_.set_for_key(true);
+    }
+  }
+
+  void finalize() {
+    for (ConstraintViolation& violation : violations) {
+      if (violation.proto().has_field()) {
+        std::reverse(
+            violation.proto_.mutable_field()->mutable_elements()->begin(),
+            violation.proto_.mutable_field()->mutable_elements()->end());
+        *violation.proto_.mutable_field_path() = internal::fieldPathString(violation.proto().field());
+      }
+      if (violation.proto().has_rule()) {
+        std::reverse(
+            violation.proto_.mutable_rule()->mutable_elements()->begin(),
+            violation.proto_.mutable_rule()->mutable_elements()->end());
+      }
     }
   }
 };
@@ -61,5 +119,34 @@ class ConstraintRules {
   virtual absl::Status Validate(
       ConstraintContext& ctx, const google::protobuf::Message& message) const = 0;
 };
+
+inline std::string fieldPathString(const FieldPath &path) {
+  std::string result;
+  for (const FieldPathElement& element : path.elements()) {
+    if (!result.empty()) {
+      result += '.';
+    }
+    switch (element.subscript_case()) {
+      case FieldPathElement::kIndex:
+        absl::StrAppend(&result, element.field_name(), "[", std::to_string(element.index()), "]");
+        break;
+      case FieldPathElement::kBoolKey:
+        absl::StrAppend(&result, element.field_name(), element.bool_key() ? "[true]" : "[false]");
+        break;
+      case FieldPathElement::kIntKey:
+        absl::StrAppend(&result, element.field_name(), "[", std::to_string(element.int_key()), "]");
+        break;
+      case FieldPathElement::kUintKey:
+        absl::StrAppend(&result, element.field_name(), "[", std::to_string(element.uint_key()), "]");
+        break;
+      case FieldPathElement::kStringKey:
+        absl::StrAppend(&result, element.field_name(), "[\"", absl::CEscape(element.string_key()), "\"]");
+        break;
+      case FieldPathElement::SUBSCRIPT_NOT_SET:
+        absl::StrAppend(&result, element.field_name());
+    }
+  }
+  return result;
+}
 
 } // namespace buf::validate::internal

--- a/buf/validate/internal/proto_field.h
+++ b/buf/validate/internal/proto_field.h
@@ -1,0 +1,155 @@
+// Copyright 2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string_view>
+
+#include "absl/status/status.h"
+#include "buf/validate/validate.pb.h"
+#include "google/protobuf/arena.h"
+#include "google/protobuf/message.h"
+
+namespace buf::validate::internal {
+
+/// ProtoField represents a field value. This may be a scalar field on a message, a repeated or map
+/// field on a message, or an item within a repeated or map field on a message.
+class ProtoField {
+ public:
+  /// Constructs a new ProtoField representing the field specified by descriptor under the provided
+  /// message. The provided descriptor should be contained by the provided message, although the
+  /// field need not be present. If the field is a repeated or map field, index may be specified to
+  /// point to a specific index; otherwise, the sentinel value -1 (default) should be provided.
+  ProtoField(
+      const google::protobuf::Message* message,
+      const google::protobuf::FieldDescriptor* descriptor,
+      int index = -1)
+      : message_{message}, descriptor_{descriptor}, index_{index} {}
+
+  [[nodiscard]] const google::protobuf::Message* message() const { return message_; }
+
+  [[nodiscard]] const google::protobuf::FieldDescriptor* descriptor() const { return descriptor_; }
+
+  [[nodiscard]] int index() const { return index_; }
+
+  /// Returns true if this ProtoField instance refers to a repeated or map field, rather than a
+  /// singular value.
+  [[nodiscard]] bool is_repeated() const { return descriptor_->is_repeated() && index_ == -1; }
+
+  /// If this ProtoField references a repeated field, returns the number of items in the repeated
+  /// field. Otherwise, always returns zero.
+  [[nodiscard]] int size() const {
+    if (!is_repeated()) {
+      return 0;
+    }
+    return message_->GetReflection()->FieldSize(*message_, descriptor_);
+  }
+
+  /// If this ProtoField references a repeated field, and the provided index is a valid index into
+  /// this repeated field, returns a ProtoField referencing the specific item at the provided index.
+  [[nodiscard]] absl::optional<ProtoField> at(int index) const {
+    if (index < 0 || !is_repeated() ||
+        index >= message_->GetReflection()->FieldSize(*message_, descriptor_)) {
+      return absl::nullopt;
+    }
+    return ProtoField{message_, descriptor_, index};
+  }
+
+  using Value = absl::variant<
+      absl::monostate,
+      int64_t,
+      uint64_t,
+      double,
+      bool,
+      std::string,
+      const google::protobuf::Message*>;
+
+  /// Returns a variant representing the value of this ProtoField, if this field references a
+  /// singular value. If is_repeated() returns true, you must instead call at(...) to get a specific
+  /// item within the repeated field or map; this method will return the monostate value otherwise.
+  [[nodiscard]] Value variant() const {
+    if (is_repeated()) {
+      return absl::monostate{};
+    }
+    if (!descriptor_->is_repeated() &&
+        !message_->GetReflection()->HasField(*message_, descriptor_)) {
+      return absl::monostate{};
+    }
+    switch (descriptor_->cpp_type()) {
+      case google::protobuf::FieldDescriptor::CPPTYPE_INT32:
+        if (index_ != -1) {
+          return static_cast<int64_t>(
+              message_->GetReflection()->GetRepeatedInt32(*message_, descriptor_, index_));
+        }
+        return static_cast<int64_t>(message_->GetReflection()->GetInt32(*message_, descriptor_));
+      case google::protobuf::FieldDescriptor::CPPTYPE_INT64:
+        if (index_ != -1) {
+          return message_->GetReflection()->GetRepeatedInt64(*message_, descriptor_, index_);
+        }
+        return message_->GetReflection()->GetInt64(*message_, descriptor_);
+      case google::protobuf::FieldDescriptor::CPPTYPE_ENUM:
+        if (index_ != -1) {
+          return static_cast<int64_t>(
+              message_->GetReflection()->GetRepeatedEnumValue(*message_, descriptor_, index_));
+        }
+        return static_cast<int64_t>(
+            message_->GetReflection()->GetEnumValue(*message_, descriptor_));
+      case google::protobuf::FieldDescriptor::CPPTYPE_UINT32:
+        if (index_ != -1) {
+          return static_cast<uint64_t>(
+              message_->GetReflection()->GetRepeatedUInt32(*message_, descriptor_, index_));
+        }
+        return static_cast<uint64_t>(message_->GetReflection()->GetUInt32(*message_, descriptor_));
+      case google::protobuf::FieldDescriptor::CPPTYPE_UINT64:
+        if (index_ != -1) {
+          return message_->GetReflection()->GetRepeatedUInt64(*message_, descriptor_, index_);
+        }
+        return message_->GetReflection()->GetUInt64(*message_, descriptor_);
+      case google::protobuf::FieldDescriptor::CPPTYPE_FLOAT:
+        if (index_ != -1) {
+          return static_cast<double>(
+              message_->GetReflection()->GetRepeatedFloat(*message_, descriptor_, index_));
+        }
+        return static_cast<double>(message_->GetReflection()->GetFloat(*message_, descriptor_));
+      case google::protobuf::FieldDescriptor::CPPTYPE_DOUBLE:
+        if (index_ != -1) {
+          return message_->GetReflection()->GetRepeatedDouble(*message_, descriptor_, index_);
+        }
+        return message_->GetReflection()->GetDouble(*message_, descriptor_);
+      case google::protobuf::FieldDescriptor::CPPTYPE_BOOL:
+        if (index_ != -1) {
+          return message_->GetReflection()->GetRepeatedBool(*message_, descriptor_, index_);
+        }
+        return message_->GetReflection()->GetBool(*message_, descriptor_);
+      case google::protobuf::FieldDescriptor::CPPTYPE_STRING:
+        if (index_ != -1) {
+          return message_->GetReflection()->GetRepeatedString(*message_, descriptor_, index_);
+        }
+        return message_->GetReflection()->GetString(*message_, descriptor_);
+      case google::protobuf::FieldDescriptor::CPPTYPE_MESSAGE:
+        if (index_ != -1) {
+          return &message_->GetReflection()->GetRepeatedMessage(*message_, descriptor_, index_);
+        }
+        return &message_->GetReflection()->GetMessage(*message_, descriptor_);
+    }
+    return absl::monostate{};
+  }
+
+ private:
+  const google::protobuf::Message* message_;
+  const google::protobuf::FieldDescriptor* descriptor_;
+  int index_;
+};
+
+} // namespace buf::validate::internal


### PR DESCRIPTION
Adds the ability to access the captured rule and field value from a Violation.

C++ protobuf doesn't really have a native "value" representation unlike other languages, so I've created a sort-of stand-in. The `ProtoField` class acts as a reference to a field on a message, and provides an interface to get a singular value as a `variant`. This should be good enough for most users, but users can also grab the information needed and use protobuf reflection directly instead if they have more complicated needs.

**This is a breaking change.** The API changes in the following ways:
- `Validator::Validate()` now returns the wrapper type `ValidationResult` instead of `Violations`. This can be converted into the protobuf `Violations` form using the `proto()` method.
- `ValidationResult.violations()` returns a `ConstraintViolation`. The underlying `Violation` can be accessed using the `proto()` method.