### PR TITLE
Implement shared dependencies system

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,0 +1,2 @@
+.build
+cmake-build-*

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ user.bazelrc
 local_tsan.bazelrc
 /.clwb/
 .vscode
+.build
+/cmake-build-*

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,7 @@ BIN := .tmp/bin
 COPYRIGHT_YEARS := 2023
 LICENSE_IGNORE := -e internal/testdata/
 LICENSE_HEADER_VERSION := 0294fdbe1ce8649ebaf5e87e8cdd588e33730bbb
-# NOTE: Keep this version in sync with the version in `/bazel/deps.bzl`.
-PROTOVALIDATE_VERSION ?= v0.10.0
+PROTOVALIDATE_VERSION ?= v$(shell <./bazel/shared_deps.json jq -j .protovalidate.meta.version)
 
 # Set to use a different compiler. For example, `GO=go1.18rc1 make test`.
 GO ?= go

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,13 @@
 workspace(name = "com_github_bufbuild_protovalidate_cc")
 
+load("//bazel:json.bzl", "json_file")
+
+json_file(
+    name = "protovalidate_cc_dependencies",
+    src = "//bazel:shared_deps.json",
+    variable = "shared_deps",
+)
+
 load("//bazel:deps.bzl", "protovalidate_cc_dependencies")
 
 protovalidate_cc_dependencies()

--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -14,81 +14,76 @@
 
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@protovalidate_cc_dependencies//:json.bzl", "shared_deps")
+
+def format_values(value, meta):
+    if type(value) == "string":
+        return value.format(**meta)
+    elif type(value) == "list":
+        return [v.format(**meta) for v in value]
+    else:
+        return value
+
+def shared_dep(name, **kwargs):
+    dep = {k: format_values(v, shared_deps[name]["meta"]) for k, v in shared_deps[name]["source"].items()}
+    return dict(dep, **kwargs)
 
 _dependencies = {
     # cel-cpp needs a newer version of absl, otherwise it will fail to build in
     # a very strange manner.
-    "com_google_absl": {
-        "sha256": "f50e5ac311a81382da7fa75b97310e4b9006474f9560ac46f54a9967f07d4ae3",
-        "strip_prefix": "abseil-cpp-20240722.0",
-        "urls": [
-            "https://github.com/abseil/abseil-cpp/archive/20240722.0.tar.gz",
-        ],
-    },
+    "com_google_absl": shared_dep(
+        name="absl",
+    ),
     # These extra dependencies are needed by protobuf.
     # This may be alleviated somewhat by protobuf v30.
     # https://github.com/protocolbuffers/protobuf/issues/17200
-    "rules_cc": {
-        "sha256": "abc605dd850f813bb37004b77db20106a19311a96b2da1c92b789da529d28fe1",
-        "strip_prefix": "rules_cc-0.0.17",
-        "urls": [
+    "rules_cc": dict(
+        sha256="abc605dd850f813bb37004b77db20106a19311a96b2da1c92b789da529d28fe1",
+        strip_prefix="rules_cc-0.0.17",
+        urls=[
             "https://github.com/bazelbuild/rules_cc/releases/download/0.0.17/rules_cc-0.0.17.tar.gz"
         ],
-    },
-    "rules_java": {
-        "sha256": "b0b8b7b2cfbf575112acf716ec788847929f322efa5c34195eb12a43d1df7e5c",
-        "urls": [
+    ),
+    "rules_java": dict(
+        sha256="b0b8b7b2cfbf575112acf716ec788847929f322efa5c34195eb12a43d1df7e5c",
+        urls=[
             "https://github.com/bazelbuild/rules_java/releases/download/8.7.2/rules_java-8.7.2.tar.gz"
         ],
-    },
-    "rules_python": {
-        "sha256": "9c6e26911a79fbf510a8f06d8eedb40f412023cf7fa6d1461def27116bff022c",
-        "strip_prefix": "rules_python-1.1.0",
-        "urls": [
+    ),
+    "rules_python": dict(
+        sha256="9c6e26911a79fbf510a8f06d8eedb40f412023cf7fa6d1461def27116bff022c",
+        strip_prefix="rules_python-1.1.0",
+        urls=[
             "https://github.com/bazelbuild/rules_python/releases/download/1.1.0/rules_python-1.1.0.tar.gz",
         ],
-    },
-    "com_google_protobuf": {
-        "sha256": "63150aba23f7a90fd7d87bdf514e459dd5fe7023fdde01b56ac53335df64d4bd",
-        "strip_prefix": "protobuf-29.2",
-        "urls": [
-            "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/archive/v29.2.tar.gz",
-            "https://github.com/protocolbuffers/protobuf/archive/v29.2.tar.gz",
-        ],
-    },
-    "rules_proto": {
-        "sha256": "dc3fb206a2cb3441b485eb1e423165b231235a1ea9b031b4433cf7bc1fa460dd",
-        "strip_prefix": "rules_proto-5.3.0-21.7",
-        "urls": [
+    ),
+    "com_google_protobuf": shared_dep(
+        name="protobuf",
+    ),
+    "rules_proto": dict(
+        sha256="dc3fb206a2cb3441b485eb1e423165b231235a1ea9b031b4433cf7bc1fa460dd",
+        strip_prefix="rules_proto-5.3.0-21.7",
+        urls=[
             "https://github.com/bazelbuild/rules_proto/archive/refs/tags/5.3.0-21.7.tar.gz",
         ],
-    },
-    "rules_buf": {
-        "sha256": "523a4e06f0746661e092d083757263a249fedca535bd6dd819a8c50de074731a",
-        "strip_prefix": "rules_buf-0.1.1",
-        "urls": [
+    ),
+    "rules_buf": dict(
+        sha256="523a4e06f0746661e092d083757263a249fedca535bd6dd819a8c50de074731a",
+        strip_prefix="rules_buf-0.1.1",
+        urls=[
             "https://github.com/bufbuild/rules_buf/archive/refs/tags/v0.1.1.zip",
         ],
-    },
-    "com_google_cel_cpp": {
-        "sha256": "dd06b708a9f4c3728e76037ec9fb14fc9f6d9c9980e5d5f3a1d047f3855a8b98",
-        "strip_prefix": "cel-cpp-0.10.0",
-        "urls": [
-            "https://github.com/google/cel-cpp/archive/v0.10.0.tar.gz",
-        ],
-        "patches": [
+    ),
+    "com_google_cel_cpp": shared_dep(
+        name="cel_cpp",
+        patches=[
             "@com_github_bufbuild_protovalidate_cc//bazel:patches/cel_cpp/0001-Allow-message-field-access-using-index-operator.patch"
         ],
-        "patch_args": ["-p1"],
-    },
-    # NOTE: Keep Version in sync with `/Makefile`.
-    "com_github_bufbuild_protovalidate": {
-        "sha256": "5879da3a72bcbd48e42f84b1eb0dfb45e3657fb68232b6b7c12c01bb937b659d",
-        "strip_prefix": "protovalidate-0.10.0",
-        "urls": [
-            "https://github.com/bufbuild/protovalidate/archive/v0.10.0.tar.gz",
-        ],
-    },
+        patch_args=["-p1"],
+    ),
+    "com_github_bufbuild_protovalidate": shared_dep(
+        name="protovalidate",
+    ),
 }
 
 def protovalidate_cc_dependencies():

--- a/bazel/json.bzl
+++ b/bazel/json.bzl
@@ -1,0 +1,30 @@
+# Copyright 2023 Buf Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def _json_file_impl(repository_ctx):
+    json_data = json.decode(repository_ctx.read(repository_ctx.attr.src))
+    repository_ctx.file("BUILD", "exports_files([ \"json.bzl\"])")
+    repository_ctx.file("json.bzl", "{}={}".format(
+        repository_ctx.attr.variable,
+        repr(json_data),
+    ))
+
+json_file = repository_rule(
+    implementation = _json_file_impl,
+    attrs = {
+        "src": attr.label(allow_single_file = True),
+        "variable": attr.string(mandatory = False),
+    },
+    local = True,
+)

--- a/bazel/shared_deps.json
+++ b/bazel/shared_deps.json
@@ -1,0 +1,53 @@
+{
+  "absl": {
+    "meta": {
+      "version": "20240722.0",
+      "cmake_min_version": "20240722"
+    },
+    "source": {
+      "sha256": "f50e5ac311a81382da7fa75b97310e4b9006474f9560ac46f54a9967f07d4ae3",
+      "strip_prefix": "abseil-cpp-{version}",
+      "urls": [
+        "https://github.com/abseil/abseil-cpp/archive/{version}.tar.gz"
+      ]
+    }
+  },
+  "protobuf": {
+    "meta": {
+      "version": "29.2",
+      "cmake_version_range": "5.27.0...<6"
+    },
+    "source": {
+      "sha256": "63150aba23f7a90fd7d87bdf514e459dd5fe7023fdde01b56ac53335df64d4bd",
+      "strip_prefix": "protobuf-{version}",
+      "urls": [
+        "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/archive/v{version}.tar.gz",
+        "https://github.com/protocolbuffers/protobuf/archive/v{version}.tar.gz"
+      ]
+    }
+  },
+  "cel_cpp": {
+    "meta": {
+      "version": "0.10.0"
+    },
+    "source": {
+      "sha256": "dd06b708a9f4c3728e76037ec9fb14fc9f6d9c9980e5d5f3a1d047f3855a8b98",
+      "strip_prefix": "cel-cpp-{version}",
+      "urls": [
+        "https://github.com/google/cel-cpp/archive/v{version}.tar.gz"
+      ]
+    }
+  },
+  "protovalidate": {
+    "meta": {
+      "version": "0.10.0"
+    },
+    "source": {
+      "sha256": "5879da3a72bcbd48e42f84b1eb0dfb45e3657fb68232b6b7c12c01bb937b659d",
+      "strip_prefix": "protovalidate-{version}",
+      "urls": [
+        "https://github.com/bufbuild/protovalidate/archive/v{version}.tar.gz"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
In preparation for CMake support (#54), we need a system to share dependencies across build systems. To do this, a technique is needed which can work with both bzlmod and WORKSPACE mode, as well as CMake.

I have chosen to specify the dependency information in a JSON manifest. This manifest contains the necessary information to derive the sources for dependencies that are shared between build systems. For dependencies which are only needed for Bazel, such as rules repositories or dependencies of them, those will be specified in `deps.bzl` still. I don't think we will need any CMake-specific dependencies.

We may need to modify/extend this later for bzlmod support.