### PR TITLE
CMake cleanup and improvements

### DIFF
--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -31,10 +31,10 @@ jobs:
         if: runner.os == 'Linux'
       - name: Set up MSVC (Windows)
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
-      - name: Set JAVA_HOME (Windows)
+      - name: Add JDK 11 to Path (Windows)
         if: runner.os == 'Windows'
         run:  |
-          Add-Content "$Env:GITHUB_ENV" "JAVA_HOME=$Env:JAVA_HOME_11_X64"
+          Add-Content "$Env:GITHUB_ENV" "PATH=$Env:JAVA_HOME_11_X64\bin;$Env:PATH"
       - name: Checkout code
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -37,13 +37,7 @@ jobs:
           fetch-depth: 1
       - name: Configure CMake
         run: |
-            cmake \
-              -B .build -S . \
-              -DBUILD_TESTING=ON \
-              -DPROTOVALIDATE_CC_ENABLE_TESTS=ON \
-              -DPROTOVALIDATE_CC_ENABLE_VENDORING=ON \
-              -DPROTOVALIDATE_CC_ENABLE_INSTALL=OFF \
-              -GNinja
+            cmake -B .build -S . -DBUILD_TESTING=ON -DPROTOVALIDATE_CC_ENABLE_TESTS=ON -DPROTOVALIDATE_CC_ENABLE_VENDORING=ON -DPROTOVALIDATE_CC_ENABLE_INSTALL=OFF -GNinja
       - name: Build with CMake
         run: |
             cmake --build .build

--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -31,6 +31,10 @@ jobs:
         if: runner.os == 'Linux'
       - name: Set up MSVC (Windows)
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+      - name: Set JAVA_HOME (Windows)
+        if: runner.os == 'Windows'
+        run:  |
+          Add-Content "$Env:GITHUB_ENV" "JAVA_HOME=$Env:JAVA_HOME_11_X64"
       - name: Checkout code
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -14,7 +14,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-24.04, macos-latest]
+        os: [ubuntu-24.04, macos-latest, windows-latest]
     name: Unit tests
     runs-on: ${{ matrix.os }}
     steps:
@@ -29,6 +29,8 @@ jobs:
       - name: Install ninja (apt)
         run: sudo apt-get install -y ninja-build
         if: runner.os == 'Linux'
+      - name: Set up MSVC (Windows)
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
       - name: Checkout code
         uses: actions/checkout@v4
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,10 @@ set(PROTOVALIDATE_LIBS
     cel_cpp::cel_cpp
     protovalidate::proto
 )
+if(WIN32)
+    # For htonl/inet_pton
+    list(APPEND PROTOVALIDATE_LIBS Ws2_32)
+endif()
 set(PROTOVALIDATE_TESTING_LIBS
     GTest::gmock_main
     protovalidate::testing_proto
@@ -86,7 +90,7 @@ if(PROTOVALIDATE_CC_ENABLE_CONFORMANCE)
     list(APPEND PROTOVALIDATE_TESTING_LIBS protovalidate_cc::conformance_runner)
 endif()
 
-if(PROTOVALIDATE_CC_ENABLE_TESTS AND BUILD_TESTING)
+if(PROTOVALIDATE_CC_ENABLE_TESTS)
     enable_testing()
 
     foreach(PROTOVALIDATE_CC_TEST_SOURCE IN LISTS PROTOVALIDATE_CC_TEST_SOURCES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,7 +102,9 @@ if(PROTOVALIDATE_CC_ENABLE_TESTS)
         unset(target_name)
     endforeach()
 
-    if(PROTOVALIDATE_CC_ENABLE_CONFORMANCE)
+    # TODO(jchadwick-buf): The conformance test runner does not work on Windows
+    # yet, due to an issue with linking the protobuf descriptors.
+    if(PROTOVALIDATE_CC_ENABLE_CONFORMANCE AND NOT WIN32)
         add_test(
             NAME protovalidate_cc_conformance
             COMMAND go run github.com/bufbuild/protovalidate/tools/protovalidate-conformance@v${PROTOVALIDATE_CC_PROTOVALIDATE_VERSION}

--- a/buf/validate/internal/extra_func.cc
+++ b/buf/validate/internal/extra_func.cc
@@ -27,6 +27,12 @@
 #include "google/protobuf/arena.h"
 #include "re2/re2.h"
 
+#ifdef _WIN32
+#include <ws2tcpip.h>
+#else
+#include <arpa/inet.h>
+#endif
+
 namespace buf::validate::internal {
 
 bool isPathValid(const std::string_view path) {

--- a/buf/validate/internal/extra_func.h
+++ b/buf/validate/internal/extra_func.h
@@ -14,8 +14,6 @@
 
 #pragma once
 
-#include <arpa/inet.h>
-
 #include <functional>
 #include <stdexcept>
 #include <string>

--- a/cmake/Deps.cmake
+++ b/cmake/Deps.cmake
@@ -17,7 +17,7 @@ set(PROTOVALIDATE_CC_PKG_CONFIG_REQS "")
 set(PROTOVALIDATE_CC_FIND_DEPENDENCIES "")
 
 # Googletest, only needed when tests are enabled.
-if((PROTOVALIDATE_CC_ENABLE_TESTS OR CEL_CPP_ENABLE_TESTS) AND BUILD_TESTING)
+if(PROTOVALIDATE_CC_ENABLE_TESTS OR CEL_CPP_ENABLE_TESTS)
     message(STATUS "protovalidate-cc: tests are enabled")
     enable_testing()
     set(ABSL_BUILD_TEST_HELPERS ON)
@@ -55,7 +55,7 @@ if((PROTOVALIDATE_CC_ENABLE_TESTS OR CEL_CPP_ENABLE_TESTS) AND BUILD_TESTING)
     endif()
 endif()
 
-if(CEL_CPP_ENABLE_TESTS AND BUILD_TESTING)
+if(CEL_CPP_ENABLE_TESTS)
     # Google Benchmark
     if(TARGET benchmark::benchmark)
         message(STATUS "protovalidate-cc: Using pre-existing google benchmark targets")
@@ -226,13 +226,16 @@ else()
                 message(FATAL_ERROR "protovalidate-cc: Installation can not be enabled when using vendored re2. Install re2 system-wide, or disable installation using -DPROTOVALIDATE_CC_ENABLE_INSTALL=OFF.")
             endif()
             message(STATUS "protovalidate-cc: Fetching re2")
-            set(RE2_PATCH ${CMAKE_CURRENT_SOURCE_DIR}/deps/patches/re2/0001-Add-RE2_INSTALL-option.patch)
+            set(RE2_PATCHES
+                ${CMAKE_CURRENT_SOURCE_DIR}/deps/patches/re2/0001-Add-RE2_INSTALL-option.patch
+            )
+            MakePatchCommand(RE2_PATCH_COMMAND "${RE2_PATCHES}")
             FetchContent_Declare(
                 re2
                 GIT_REPOSITORY "https://github.com/google/re2.git"
                 GIT_TAG "2024-04-01"
                 GIT_SHALLOW TRUE
-                PATCH_COMMAND git apply --check -R ${RE2_PATCH} || git apply ${RE2_PATCH}
+                PATCH_COMMAND ${RE2_PATCH_COMMAND}
             )
             set(RE2_INSTALL OFF)
             FetchContent_MakeAvailable(re2)
@@ -272,6 +275,7 @@ set(CEL_CPP_PATCHES
     ${CMAKE_CURRENT_SOURCE_DIR}/deps/patches/cel_cpp/0001-Allow-message-field-access-using-index-operator.patch
     ${CMAKE_CURRENT_SOURCE_DIR}/deps/patches/cel_cpp/0002-Add-missing-include-for-absl-StrCat.patch
     ${CMAKE_CURRENT_SOURCE_DIR}/deps/patches/cel_cpp/0003-Remove-unnecessary-dependency-on-cel_proto_wrap_util.patch
+    ${CMAKE_CURRENT_SOURCE_DIR}/deps/patches/cel_cpp/0004-Fix-build-on-Windows-MSVC.patch
 )
 MakePatchCommand(CEL_CPP_PATCH_COMMAND "${CEL_CPP_PATCHES}")
 message(STATUS "protovalidate-cc: Fetching cel-cpp")
@@ -338,7 +342,7 @@ target_link_libraries(protovalidate_proto PUBLIC protobuf::libprotobuf)
 add_library(protovalidate::proto ALIAS protovalidate_proto)
 list(APPEND PROTOVALIDATE_CC_EXPORT_TARGETS protovalidate_proto)
 
-if((PROTOVALIDATE_CC_ENABLE_TESTS AND BUILD_TESTING) OR PROTOVALIDATE_CC_ENABLE_CONFORMANCE)
+if(PROTOVALIDATE_CC_ENABLE_TESTS OR PROTOVALIDATE_CC_ENABLE_CONFORMANCE)
     # protoc-gen-validate; just needed for the proto files. There is no CMake
     # build, so it is always vendored for now. When building in a hermetic
     # environment, use the FETCHCONTENT_SOURCE_DIR_PROTOC_GEN_VALIDATE option to

--- a/cmake/Deps.cmake
+++ b/cmake/Deps.cmake
@@ -34,6 +34,9 @@ if(PROTOVALIDATE_CC_ENABLE_TESTS OR CEL_CPP_ENABLE_TESTS)
                 option(INSTALL_GTEST OFF)
                 option(INSTALL_GMOCK OFF)
                 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+                if(WIN32)
+                    set(gtest_disable_pthreads ON CACHE BOOL "" FORCE)
+                endif()
                 FetchContent_Declare(
                     googletest
                     URL https://github.com/google/googletest/archive/b514bdc898e2951020cbdca1304b75f5950d1f59.zip

--- a/cmake/MakePatchCommand.cmake
+++ b/cmake/MakePatchCommand.cmake
@@ -1,13 +1,95 @@
+function(ValidateGnuPatchVersion output_variable item)
+    # TODO: On Windows, programs named "patch.exe" will cause UAC elevation
+    # by default. This is very annoying. Unfortunately, it also seems hard to
+    # detect: there is an undocumented routine in Shell32 that supposedly
+    # returns whether or not a given executable needs elevation in the current
+    # context, but it does not seem to detect this special edge case. That means
+    # that if the GnuWin32 version of patch.exe, which is too old for us anyway,
+    # happens to be on the %PATH%, it will cause an annoying UAC prompt during
+    # the configuration stage. It would be nice to figure out a way to avoid
+    # this :|
+
+    # Get the output of running with --version.
+    execute_process(
+        COMMAND "${item}" --version
+        TIMEOUT 5
+        OUTPUT_VARIABLE output
+        RESULT_VARIABLE result
+    )
+
+    if(NOT result EQUAL 0)
+        message(WARNING "protovalidate-cc: patch executable ${item} returned ${result}; skipping")
+        set(${output_variable} FALSE PARENT_SCOPE)
+        return()
+    endif()
+
+    if(NOT output MATCHES "GNU patch ([0-9]+)[.]([0-9]+)")
+        message(WARNING "protovalidate-cc: patch executable ${item} did not seem to return a version in --version, output: ${output}; skipping")
+        set(${output_variable} FALSE PARENT_SCOPE)
+        return()
+    endif()
+
+    set(major_version ${CMAKE_MATCH_1})
+    set(minor_version ${CMAKE_MATCH_2})
+
+    if(major_version LESS 2 OR (major_version EQUAL 2 AND minor_version LESS 7))
+        message(WARNING "protovalidate-cc: patch executable ${item} too old (${major_version}.${minor_version}); GNU patch 2.7 or higher is required. skipping")
+        set(${output_variable} FALSE PARENT_SCOPE)
+        return()
+    endif()
+
+    message(STATUS "protovalidate-cc: found GNU patch ${major_version}.${minor_version}")
+    set(${output_variable} TRUE PARENT_SCOPE)
+endfunction()
+
 function(MakePatchCommand output_variable patch_files)
+    set(validator_args "")
+    if(WIN32)
+        set(validator_args VALIDATOR ValidateGnuPatchVersion)
+    endif()
+
+    # Try to find patch executable.
+    find_program(PATCH_EXECUTABLE
+        NAMES "patch"
+              "patch.exe"
+        PATHS "$ENV{ProgramFiles}\\Git\\usr\\bin\\"
+              "$ENV{ProgramFiles\(x86\)}\\Git\\usr\\bin\\"
+              "C:\\msys64\\usr\\bin\\"
+        ${validator_args}
+    )
+    if(NOT PATCH_EXECUTABLE)
+        message(FATAL_ERROR "GNU patch 2.7+ not found. Please install it, or set PATCH_EXECUTABLE.")
+    endif()
+
     # Be careful when trying to reason about this logic. Keep in mind that CMake
     # lists are just semicolon-separated strings, and if you aren't careful
     # about when you quote and when you don't, you could wind up in a world of
     # hurt very easily.
-    set(patch_command_list "true")
-    foreach(patch_file ${patch_files})
-        string(APPEND patch_command_list
-            " && (echo 'Applying patch ${patch_file}' && patch --dry-run -sfR -p1 < ${patch_file} || patch -p1 < ${patch_file})"
-        )
-    endforeach()
-    set(${output_variable} /bin/sh -c "${patch_command_list}" PARENT_SCOPE)
+    if (WIN32)
+        set(patch_command "set _z=")
+        foreach(patch_file ${patch_files})
+            string(APPEND patch_command
+                " && @echo Applying patch ${patch_file} && "
+                "\"${PATCH_EXECUTABLE}\" --dry-run -sfR -p1 -i \"${patch_file}\" ||"
+                "\"${PATCH_EXECUTABLE}\" -p1 -i \"${patch_file}\""
+            )
+        endforeach()
+        # It seems impossible to generate a working command on Windows without a
+        # temporary file. We can use cmd /C much like sh -c, but CMake seems to
+        # munge both semicolons and quoted strings in a way that makes it seem
+        # unlikely you can do this as a one-liner.
+        string(SHA256 patch_command_hash "${patch_command}")
+        string(SUBSTRING "${patch_command_hash}" 0 8 patch_command_shorthash)
+        set(batch_file "${CMAKE_CURRENT_BINARY_DIR}/apply-patches-${patch_command_shorthash}.cmd")
+        file(WRITE "${batch_file}" "${patch_command}")
+        set(${output_variable} "${batch_file}" PARENT_SCOPE)
+    else()
+        set(patch_command_list "true")
+        foreach(patch_file ${patch_files})
+            string(APPEND patch_command_list
+                " && (echo 'Applying patch ${patch_file}' && ${PATCH_EXECUTABLE} --dry-run -sfR -p1 < ${patch_file} || ${PATCH_EXECUTABLE} -p1 < ${patch_file})"
+            )
+        endforeach()
+        set(${output_variable} /bin/sh -c "${patch_command_list}" PARENT_SCOPE)
+    endif()
 endfunction()

--- a/cmake/README.md
+++ b/cmake/README.md
@@ -4,6 +4,13 @@ protovalidate-cc comes with a CMake build script. You can use this to embed
 protovalidate-cc into your existing CMake project or install protovalidate-cc
 system-wide.
 
+protovalidate-cc is known to build successfully on macOS, Linux and Windows,
+with GCC, Clang or MSVC. Please note that Windows support is still preliminary;
+some Windows functionality hasn't been validated, and protovalidate-cc supplies
+downstream patches to dependencies for Windows support.
+
+(Please note that Windows support is currently limited to building with CMake.)
+
 ## CMake Flags
 
 protovalidate-cc provides the following options:

--- a/cmake/README.md
+++ b/cmake/README.md
@@ -83,6 +83,14 @@ Depending on your project setup, these can be sourced in different ways:
   `FETCHCONTENT_SOURCE_DIR_CEL_CPP` prior to running
   `FetchContent_MakeAvailable(protovalidate_cc)`.
 
+In addition to these dependencies, there are some build-time dependencies:
+
+- Git, for getting the protovalidate-cc version
+
+- Java 11, for running the ANTLR 4 compiler
+
+- GNU patch 2.7 or Darwin patch 2.0, for applying Git patches
+
 ## Embedding
 
 protovalidate-cc requires C++17 or higher. Near the top of your CMakeLists,

--- a/cmake/README.md
+++ b/cmake/README.md
@@ -69,8 +69,8 @@ Depending on your project setup, these can be sourced in different ways:
   ANTLR 4 compiler will be downloaded from the Internet, and ran using `java`
   during the compilation process (naturally, this requires a JRE installation.)
   You can override this behavior by setting `FETCHCONTENT_SOURCE_DIR_ANTLR4` and
-  `ANTLR4_JAR_LOCATION` to the location of a copy of the ANTLR 4 source code and
-  a compiled ANTLR 4 compiler JAR before running
+  `PROTOVALIDATE_CC_ANTLR4_JAR_LOCATION` to the location of a copy of the ANTLR
+  4 source code and a compiled ANTLR 4 compiler JAR before running
   `FetchContent_MakeAvailable(protovalidate_cc)`.
 
 - A copy of googleapis is always fetched for cel-cpp. You can override this

--- a/cmake/cel-cpp/CMakeLists.txt
+++ b/cmake/cel-cpp/CMakeLists.txt
@@ -216,7 +216,7 @@ target_include_directories(cel_cpp PUBLIC
 target_compile_definitions(cel_cpp PRIVATE ANTLR4CPP_USING_ABSEIL)
 add_library(cel_cpp::cel_cpp ALIAS cel_cpp)
 
-if(CEL_CPP_ENABLE_TESTS AND BUILD_TESTING)
+if(CEL_CPP_ENABLE_TESTS)
     enable_testing()
 
     # Generate C++ code for cel spec protos

--- a/deps/patches/cel_cpp/0004-Fix-build-on-Windows-MSVC.patch
+++ b/deps/patches/cel_cpp/0004-Fix-build-on-Windows-MSVC.patch
@@ -1,0 +1,127 @@
+From 99917828897f5ee4b75a47182d7c1fee328605ee Mon Sep 17 00:00:00 2001
+From: John Chadwick <jchadwick@buf.build>
+Date: Fri, 21 Mar 2025 20:16:07 -0400
+Subject: [PATCH 4/4] Fix build on Windows/MSVC
+
+Some fixes+hacks+workarounds for build issues on MSVC.
+---
+ bazel/cel_cc_embed.cc                | 2 +-
+ common/internal/shared_byte_string.h | 4 ++--
+ common/types/list_type.cc            | 2 +-
+ common/types/map_type.cc             | 4 ++--
+ common/types/optional_type.cc        | 2 +-
+ internal/json.cc                     | 5 +++++
+ internal/well_known_types.cc         | 5 +++++
+ 7 files changed, 17 insertions(+), 7 deletions(-)
+
+diff --git a/bazel/cel_cc_embed.cc b/bazel/cel_cc_embed.cc
+index a9f0aec2..80515457 100644
+--- a/bazel/cel_cc_embed.cc
++++ b/bazel/cel_cc_embed.cc
+@@ -34,7 +34,7 @@ namespace {
+ 
+ std::vector<uint8_t> ReadFile(const std::string& path) {
+   ABSL_CHECK(!path.empty()) << "--in is required";
+-  std::ifstream file(path);
++  std::ifstream file(path, std::ifstream::binary);
+   ABSL_CHECK(file.is_open()) << path;
+   file.seekg(0, file.end);
+   ABSL_CHECK(file.good());
+diff --git a/common/internal/shared_byte_string.h b/common/internal/shared_byte_string.h
+index fd8228c0..c6660f80 100644
+--- a/common/internal/shared_byte_string.h
++++ b/common/internal/shared_byte_string.h
+@@ -57,12 +57,12 @@ inline constexpr uintptr_t kByteStringReferenceCountPooledBit = uintptr_t{1}
+                                                                 << 0;
+ 
+ #ifdef _MSC_VER
+-#pragma pack(pack, 1)
++#pragma pack(push, 1)
+ #endif
+ 
+ struct ABSL_ATTRIBUTE_PACKED SharedByteStringHeader final {
+   // True if the content is `absl::Cord`.
+-  bool is_cord : 1;
++  size_t is_cord : 1;
+   // Only used when `is_cord` is `false`.
+   size_t size : sizeof(size_t) * 8 - 1;
+ 
+diff --git a/common/types/list_type.cc b/common/types/list_type.cc
+index 41a6f2f1..f4dba5e5 100644
+--- a/common/types/list_type.cc
++++ b/common/types/list_type.cc
+@@ -28,7 +28,7 @@ namespace common_internal {
+ 
+ namespace {
+ 
+-ABSL_CONST_INIT const ListTypeData kDynListTypeData;
++const ListTypeData kDynListTypeData;
+ 
+ }  // namespace
+ 
+diff --git a/common/types/map_type.cc b/common/types/map_type.cc
+index e0c15df5..1df3b52b 100644
+--- a/common/types/map_type.cc
++++ b/common/types/map_type.cc
+@@ -28,11 +28,11 @@ namespace common_internal {
+ 
+ namespace {
+ 
+-ABSL_CONST_INIT const MapTypeData kDynDynMapTypeData = {
++const MapTypeData kDynDynMapTypeData = {
+     .key_and_value = {DynType(), DynType()},
+ };
+ 
+-ABSL_CONST_INIT const MapTypeData kStringDynMapTypeData = {
++const MapTypeData kStringDynMapTypeData = {
+     .key_and_value = {StringType(), DynType()},
+ };
+ 
+diff --git a/common/types/optional_type.cc b/common/types/optional_type.cc
+index a37300bb..3ec51ed8 100644
+--- a/common/types/optional_type.cc
++++ b/common/types/optional_type.cc
+@@ -47,7 +47,7 @@ static_assert(offsetof(OptionalTypeData, parameters_size) ==
+ static_assert(offsetof(OptionalTypeData, parameter) ==
+               offsetof(OpaqueTypeData, parameters));
+ 
+-ABSL_CONST_INIT const DynOptionalTypeData kDynOptionalTypeData = {
++const DynOptionalTypeData kDynOptionalTypeData = {
+     .optional =
+         {
+             .name = OptionalType::kName,
+diff --git a/internal/json.cc b/internal/json.cc
+index aa5d6cce..c658a1cd 100644
+--- a/internal/json.cc
++++ b/internal/json.cc
+@@ -53,6 +53,11 @@
+ #include "google/protobuf/message_lite.h"
+ #include "google/protobuf/util/time_util.h"
+ 
++// Workaround for Windows macro conflict.
++#ifdef GetMessage
++#undef GetMessage
++#endif
++
+ namespace cel::internal {
+ 
+ namespace {
+diff --git a/internal/well_known_types.cc b/internal/well_known_types.cc
+index f6511cff..e5e418af 100644
+--- a/internal/well_known_types.cc
++++ b/internal/well_known_types.cc
+@@ -56,6 +56,11 @@
+ #include "google/protobuf/reflection.h"
+ #include "google/protobuf/util/time_util.h"
+ 
++// Workaround for Windows macro conflict.
++#ifdef GetMessage
++#undef GetMessage
++#endif
++
+ namespace cel::well_known_types {
+ 
+ namespace {
+-- 
+2.47.2
+


### PR DESCRIPTION
- Antlr4 improvements: Jar download now checks hash, uses CACHE variables
- MakePatchCommand now tries to resolve the `patch` command ahead of time
- Add preliminary support for Windows