### PR TITLE
CMake: Set up compile_commands.json automatically

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,2 +1,3 @@
 .build*
 cmake-build-*
+.cache

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,10 @@
 *.out
 *.app
 
+# Clangd
+/.cache
+/compile_commands.json
+
 # Additional exclusions
 /.tmp/
 *.pprof

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,17 @@ else()
     option(PROTOVALIDATE_CC_ENABLE_INSTALL "Enable protovalidate-cc installation targets" ON)
     option(PROTOVALIDATE_CC_ENABLE_TESTS "Enable protovalidate-cc unit tests" ON)
     option(PROTOVALIDATE_CC_ENABLE_CONFORMANCE "Build conformance runner" ON)
+
+    # Set up compile_commands.json automatically when standalone.
+    option(PROTOVALIDATE_CC_SETUP_COMPILE_COMMANDS "Set up compile_commands.json" ON)
+    if(PROTOVALIDATE_CC_SETUP_COMPILE_COMMANDS)
+        set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+        execute_process(
+            COMMAND ${CMAKE_COMMAND} -E create_symlink
+                    ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json
+                    ${CMAKE_CURRENT_SOURCE_DIR}/compile_commands.json
+        )
+    endif()
 endif()
 
 if(CMAKE_CXX_STANDARD LESS 17)


### PR DESCRIPTION
This allows clangd to provide code intelligence. Most completions will work after configuration, although some completions (e.g. involving generated code) will require a build.

Generating a compile_commands.json file is non-trivial for Bazel so this should enable a better developer experience for people working on protovalidate-cc. Clangd can be used with a large variety of editors (Vim, Zed, Visual Studio Code, etc.)