### PR TITLE
Rename constraint -> rule globally

### DIFF
--- a/buf/validate/internal/BUILD.bazel
+++ b/buf/validate/internal/BUILD.bazel
@@ -15,11 +15,11 @@
 package(default_visibility = ["//:__subpackages__"])
 
 cc_library(
-    name = "cel_constraint_rules",
-    srcs = ["cel_constraint_rules.cc"],
-    hdrs = ["cel_constraint_rules.h"],
+    name = "cel_validation_rules",
+    srcs = ["cel_validation_rules.cc"],
+    hdrs = ["cel_validation_rules.h"],
     deps = [
-        ":constraint_rules",
+        ":validation_rules",
         "@com_google_cel_cpp//eval/public:activation",
         "@com_google_cel_cpp//eval/public:cel_expression",
         "@com_google_cel_cpp//eval/public:cel_value",
@@ -43,8 +43,8 @@ cc_library(
 )
 
 cc_library(
-    name = "constraint_rules",
-    hdrs = ["constraint_rules.h"],
+    name = "validation_rules",
+    hdrs = ["validation_rules.h"],
     deps = [
         "@com_github_bufbuild_protovalidate//proto/protovalidate/buf/validate:validate_proto_cc",
         ":proto_field",
@@ -93,18 +93,18 @@ cc_library(
     hdrs = ["field_rules.h"],
     deps = [
         ":cel_rules",
-        ":constraint",
+        ":rules",
         "@com_google_absl//absl/status:statusor",
         "@com_google_protobuf//:protobuf",
     ],
 )
 
 cc_library(
-    name = "constraint",
-    srcs = ["constraints.cc"],
-    hdrs = ["constraints.h"],
+    name = "rules",
+    srcs = ["rules.cc"],
+    hdrs = ["rules.h"],
     deps = [
-        ":cel_constraint_rules",
+        ":cel_validation_rules",
         ":extra_func",
         "@com_github_bufbuild_protovalidate//proto/protovalidate/buf/validate:validate_proto_cc",
         "@com_google_cel_cpp//eval/public:activation",
@@ -119,10 +119,10 @@ cc_library(
 )
 
 cc_test(
-    name = "constraint_test",
-    srcs = ["constraints_test.cc"],
+    name = "rules_test",
+    srcs = ["rules_test.cc"],
     deps = [
-        ":constraint",
+        ":rules",
         "@com_google_cel_cpp//eval/public:activation",
         "@com_google_googletest//:gtest_main",
     ],

--- a/buf/validate/internal/field_rules.h
+++ b/buf/validate/internal/field_rules.h
@@ -16,7 +16,7 @@
 
 #include "absl/status/statusor.h"
 #include "buf/validate/internal/cel_rules.h"
-#include "buf/validate/internal/constraints.h"
+#include "buf/validate/internal/rules.h"
 #include "google/protobuf/arena.h"
 #include "google/protobuf/descriptor.h"
 
@@ -24,7 +24,7 @@ namespace buf::validate::internal {
 
 template <typename R>
 absl::Status BuildScalarFieldRules(
-    FieldConstraintRules& result,
+    FieldValidationRules& result,
     std::unique_ptr<MessageFactory>& messageFactory,
     bool allowUnknownFields,
     google::protobuf::Arena* arena,
@@ -38,13 +38,13 @@ absl::Status BuildScalarFieldRules(
     if (field->type() == google::protobuf::FieldDescriptor::TYPE_MESSAGE) {
       if (field->message_type()->full_name() != wrapperName) {
         return absl::FailedPreconditionError(absl::StrFormat(
-            "field type does not match constraint type: %s != %s",
+            "field type does not match rule type: %s != %s",
             field->type_name(),
             google::protobuf::FieldDescriptor::TypeName(expectedType)));
       }
     } else {
       return absl::FailedPreconditionError(absl::StrFormat(
-          "field type does not match constraint type: %s != %s",
+          "field type does not match rule type: %s != %s",
           google::protobuf::FieldDescriptor::TypeName(field->type()),
           google::protobuf::FieldDescriptor::TypeName(expectedType)));
     }
@@ -53,7 +53,7 @@ absl::Status BuildScalarFieldRules(
 }
 
 template <typename R>
-absl::StatusOr<std::unique_ptr<FieldConstraintRules>> NewScalarFieldRules(
+absl::StatusOr<std::unique_ptr<FieldValidationRules>> NewScalarFieldRules(
     std::unique_ptr<MessageFactory>& messageFactory,
     bool allowUnknownFields,
     google::protobuf::Arena* arena,
@@ -63,7 +63,7 @@ absl::StatusOr<std::unique_ptr<FieldConstraintRules>> NewScalarFieldRules(
     const R& rules,
     google::protobuf::FieldDescriptor::Type expectedType,
     std::string_view wrapperName = "") {
-  auto result = std::make_unique<FieldConstraintRules>(field, fieldLvl);
+  auto result = std::make_unique<FieldValidationRules>(field, fieldLvl);
   auto status = BuildScalarFieldRules(
       *result,
       messageFactory,
@@ -81,7 +81,7 @@ absl::StatusOr<std::unique_ptr<FieldConstraintRules>> NewScalarFieldRules(
   return result;
 }
 
-absl::StatusOr<std::unique_ptr<FieldConstraintRules>> NewFieldRules(
+absl::StatusOr<std::unique_ptr<FieldValidationRules>> NewFieldRules(
     std::unique_ptr<MessageFactory>& messageFactory,
     bool allowUnknownFields,
     google::protobuf::Arena* arena,

--- a/buf/validate/internal/message_rules.cc
+++ b/buf/validate/internal/message_rules.cc
@@ -18,25 +18,24 @@
 
 namespace buf::validate::internal {
 
-absl::StatusOr<std::unique_ptr<MessageConstraintRules>> BuildMessageRules(
-    google::api::expr::runtime::CelExpressionBuilder& builder,
-    const MessageRules& constraints) {
-  auto result = std::make_unique<MessageConstraintRules>();
-  for (const auto& constraint : constraints.cel()) {
-    if (auto status = result->Add(builder, constraint, absl::nullopt, nullptr); !status.ok()) {
+absl::StatusOr<std::unique_ptr<MessageValidationRules>> BuildMessageRules(
+    google::api::expr::runtime::CelExpressionBuilder& builder, const MessageRules& rules) {
+  auto result = std::make_unique<MessageValidationRules>();
+  for (const auto& rule : rules.cel()) {
+    if (auto status = result->Add(builder, rule, absl::nullopt, nullptr); !status.ok()) {
       return status;
     }
   }
   return result;
 }
 
-Constraints NewMessageConstraints(
+Rules NewMessageRules(
     std::unique_ptr<MessageFactory>& messageFactory,
     bool allowUnknownFields,
     google::protobuf::Arena* arena,
     google::api::expr::runtime::CelExpressionBuilder& builder,
     const google::protobuf::Descriptor* descriptor) {
-  std::vector<std::unique_ptr<ConstraintRules>> result;
+  std::vector<std::unique_ptr<ValidationRules>> result;
   if (descriptor->options().HasExtension(buf::validate::message)) {
     const auto& msgLvl = descriptor->options().GetExtension(buf::validate::message);
     if (msgLvl.disabled()) {
@@ -71,7 +70,7 @@ Constraints NewMessageConstraints(
       continue;
     }
     const auto& oneofLvl = oneof->options().GetExtension(buf::validate::oneof);
-    result.emplace_back(std::make_unique<OneofConstraintRules>(oneof, oneofLvl));
+    result.emplace_back(std::make_unique<OneofValidationRules>(oneof, oneofLvl));
   }
 
   return result;

--- a/buf/validate/internal/message_rules.h
+++ b/buf/validate/internal/message_rules.h
@@ -15,8 +15,8 @@
 #pragma once
 
 #include "absl/status/statusor.h"
-#include "buf/validate/internal/constraints.h"
 #include "buf/validate/internal/message_factory.h"
+#include "buf/validate/internal/rules.h"
 #include "buf/validate/validate.pb.h"
 #include "eval/public/cel_expression.h"
 #include "google/protobuf/arena.h"
@@ -24,17 +24,16 @@
 
 namespace buf::validate::internal {
 
-using Constraints = absl::StatusOr<std::vector<std::unique_ptr<ConstraintRules>>>;
+using Rules = absl::StatusOr<std::vector<std::unique_ptr<ValidationRules>>>;
 
-Constraints NewMessageConstraints(
+Rules NewMessageRules(
     std::unique_ptr<MessageFactory>& messageFactory,
     bool allowUnknownFields,
     google::protobuf::Arena* arena,
     google::api::expr::runtime::CelExpressionBuilder& builder,
     const google::protobuf::Descriptor* descriptor);
 
-absl::StatusOr<std::unique_ptr<MessageConstraintRules>> BuildMessageRules(
-    google::api::expr::runtime::CelExpressionBuilder& builder,
-    const MessageRules& constraints);
+absl::StatusOr<std::unique_ptr<MessageValidationRules>> BuildMessageRules(
+    google::api::expr::runtime::CelExpressionBuilder& builder, const MessageRules& rules);
 
 } // namespace buf::validate::internal

--- a/buf/validate/validator_test.cc
+++ b/buf/validate/validator_test.cc
@@ -126,7 +126,7 @@ TEST(ValidatorTest, ValidateURI_NotFound) {
   EXPECT_EQ(violations_or.status().code(), absl::StatusCode::kNotFound);
   EXPECT_EQ(
       violations_or.status().message(),
-      "constraints not loaded for message: buf.validate.conformance.cases.StringURI");
+      "rules not loaded for message: buf.validate.conformance.cases.StringURI");
 }
 
 TEST(ValidatorTest, ValidateRelativeURIFailure) {
@@ -408,7 +408,7 @@ TEST(ValidatorTest, ValidateEndsWithSuccess) {
   EXPECT_EQ(violations_or.value().violations_size(), 0);
 }
 
-TEST(ValidatorTest, MessageConstraint) {
+TEST(ValidatorTest, MessageRule) {
   conformance::cases::custom_rules::MessageExpressions message_expressions;
   message_expressions.mutable_e();
   auto factory_or = ValidatorFactory::New();
@@ -419,13 +419,11 @@ TEST(ValidatorTest, MessageConstraint) {
   auto violations_or = validator.Validate(message_expressions);
   ASSERT_TRUE(violations_or.ok()) << violations_or.status();
   ASSERT_EQ(violations_or.value().violations_size(), 3);
-  EXPECT_EQ(
-      violations_or.value().violations(0).proto().rule_id(), "message_expression_scalar");
+  EXPECT_EQ(violations_or.value().violations(0).proto().rule_id(), "message_expression_scalar");
   EXPECT_EQ(violations_or.value().violations(0).proto().message(), "a must be less than b");
   EXPECT_EQ(violations_or.value().violations(1).proto().rule_id(), "message_expression_enum");
   EXPECT_EQ(violations_or.value().violations(1).proto().message(), "c must not equal d");
-  EXPECT_EQ(
-      violations_or.value().violations(2).proto().rule_id(), "message_expression_nested");
+  EXPECT_EQ(violations_or.value().violations(2).proto().rule_id(), "message_expression_nested");
   EXPECT_EQ(violations_or.value().violations(2).proto().message(), "a must be greater than b");
 }
 

--- a/cmake/example/main.cc
+++ b/cmake/example/main.cc
@@ -22,7 +22,7 @@ int main(int argc, char** argv) {
   google::protobuf::Arena arena;
   auto factory = buf::validate::ValidatorFactory::New().value();
   auto validator = factory->NewValidator(&arena, false);
-  
+
   auto results = validator.Validate(user).value();
   if (results.violations_size() > 0) {
     std::cout << "validation failed" << std::endl;
@@ -36,7 +36,7 @@ int main(int argc, char** argv) {
     // Print the validation message.
     std::cout << p.proto().message() << std::endl;
 
-    // Print the entire ConstraintViolation to see its structure.
+    // Print the entire RuleViolation to see its structure.
     std::cout << p.proto().DebugString() << std::endl;
   }
 }


### PR DESCRIPTION
Following the change from protovalidate v0.11.0 onward, the term "constraint" is now removed in places where it referred to protovalidate rules, using the following nomenclature:
- ConstraintRule -> ValidationRule
- Constraint -> Rule
etc.

This is an API breaking change, since names of public structures have changed.