### PR TITLE
Update to pv release candidate

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -42,4 +42,4 @@ archive_override(
     ]
 )
 
-bazel_dep(name = "protovalidate", version = "0.12.0", repo_name = "com_github_bufbuild_protovalidate")
+bazel_dep(name = "protovalidate", version = "1.0.0-rc.1", repo_name = "com_github_bufbuild_protovalidate")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -182,8 +182,8 @@
     "https://bcr.bazel.build/modules/protoc-gen-validate/1.0.4.bcr.2/MODULE.bazel": "c4bd2c850211ff5b7dadf9d2d0496c1c922fdedc303c775b01dfd3b3efc907ed",
     "https://bcr.bazel.build/modules/protoc-gen-validate/1.0.4.bcr.2/source.json": "4cc97f70b521890798058600a927ce4b0def8ee84ff2a5aa632aabcb4234aa0b",
     "https://bcr.bazel.build/modules/protoc-gen-validate/1.0.4/MODULE.bazel": "b8913c154b16177990f6126d2d2477d187f9ddc568e95ee3e2d50fc65d2c494a",
-    "https://bcr.bazel.build/modules/protovalidate/0.12.0/MODULE.bazel": "bc66bbcd5073c99a3561a7e174d24a403847c3bf7e31b9a74af21fce994052ae",
-    "https://bcr.bazel.build/modules/protovalidate/0.12.0/source.json": "258130f39f1040045f14555ade7005583d8d917461c56485c0897c9935c9d061",
+    "https://bcr.bazel.build/modules/protovalidate/1.0.0-rc.1/MODULE.bazel": "97ac1e244c63781d40c38ce15ed9d2b1c923833ba2494d92fe80bf247d3fe30a",
+    "https://bcr.bazel.build/modules/protovalidate/1.0.0-rc.1/source.json": "e3d4894e0a64c5ce5ad38639c5468fb8dae6644a6cff2d77c576d3ad5159017a",
     "https://bcr.bazel.build/modules/pybind11_bazel/2.11.1/MODULE.bazel": "88af1c246226d87e65be78ed49ecd1e6f5e98648558c14ce99176da041dc378e",
     "https://bcr.bazel.build/modules/pybind11_bazel/2.12.0/MODULE.bazel": "e6f4c20442eaa7c90d7190d8dc539d0ab422f95c65a57cc59562170c58ae3d34",
     "https://bcr.bazel.build/modules/pybind11_bazel/2.12.0/source.json": "6900fdc8a9e95866b8c0d4ad4aba4d4236317b5c1cd04c502df3f0d33afed680",
@@ -507,7 +507,7 @@
     "@@rules_buf+//buf:extensions.bzl%buf": {
       "general": {
         "bzlTransitiveDigest": "Cn52bY/1OxGKNv4TI5yExj2vL9hBgfRj4HOOcjWQTdQ=",
-        "usagesDigest": "//3dRKE/oaLU3Hr27cjfe4m83I5xOotrJsdQi1sVSiM=",
+        "usagesDigest": "LhpNrCpDf26/nlI1amvlckINVn131BBRmXO9ypWRwAE=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},

--- a/deps/shared_deps.json
+++ b/deps/shared_deps.json
@@ -38,10 +38,10 @@
   },
   "protovalidate": {
     "meta": {
-      "version": "0.12.0"
+      "version": "1.0.0-rc.1"
     },
     "source": {
-      "sha256": "990fef0b4d0beeaa1581f4cb6ddcce19363b43b62d6526e75d9a8e4f78e7468f",
+      "sha256": "f04ecb455e58172bcd7b011dac4ef35ffbe4f6acf0ec7021433bed4e2289de2b",
       "strip_prefix": "protovalidate-{version}",
       "urls": [
         "https://github.com/bufbuild/protovalidate/releases/download/v{version}/protovalidate-{version}.tar.gz"


### PR DESCRIPTION
This updates the repo to the v1.0.0-rc.1 release candidate for Protovalidate.