### PR TITLE
Pull cel-cpp from the BCR

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -28,18 +28,6 @@ bazel_dep(name = "googletest", version = "1.16.0.bcr.1", repo_name = "com_google
 
 bazel_dep(name = "abseil-cpp", version = "20240722.0", repo_name = "com_google_absl")
 
-bazel_dep(name = "cel-cpp", repo_name = "com_google_cel_cpp")
-
-archive_override(
-    module_name = "cel-cpp",
-    strip_prefix = "cel-cpp-0.11.0",
-    patches=[
-        "@protovalidate-cc//deps:patches/cel_cpp/0001-Fix-build-on-Windows-MSVC.patch",
-    ],
-    patch_args=["-p1"],
-    urls = [
-        "https://github.com/google/cel-cpp/archive/v0.11.0.tar.gz"
-    ]
-)
+bazel_dep(name = "cel-cpp", version = "0.11.0", repo_name = "com_google_cel_cpp")
 
 bazel_dep(name = "protovalidate", version = "1.0.0-rc.1", repo_name = "com_github_bufbuild_protovalidate")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -70,6 +70,8 @@
     "https://bcr.bazel.build/modules/buildozer/7.1.2/source.json": "c9028a501d2db85793a6996205c8de120944f50a0d570438fcae0457a5f9d1f8",
     "https://bcr.bazel.build/modules/c-ares/1.15.0/MODULE.bazel": "ba0a78360fdc83f02f437a9e7df0532ad1fbaa59b722f6e715c11effebaa0166",
     "https://bcr.bazel.build/modules/c-ares/1.15.0/source.json": "5e3ed991616c5ec4cc09b0893b29a19232de4a1830eb78c567121bfea87453f7",
+    "https://bcr.bazel.build/modules/cel-cpp/0.11.0/MODULE.bazel": "1015879a50a01ad42d81eba3fa9b94141f73ed62f715ca87939706d4dbbdde15",
+    "https://bcr.bazel.build/modules/cel-cpp/0.11.0/source.json": "269ad902d7dff7114f6c0d050a1f0469813800c5b9f34e591818ab777cd1d954",
     "https://bcr.bazel.build/modules/cel-spec/0.15.0/MODULE.bazel": "e1eed53d233acbdcf024b4b0bc1528116d92c29713251b5154078ab1348cb600",
     "https://bcr.bazel.build/modules/cel-spec/0.23.0/MODULE.bazel": "d72e01a364f846200e46e7ebea3f9a7dc113cd47e849b88a554ee17f39aabcef",
     "https://bcr.bazel.build/modules/cel-spec/0.23.0/source.json": "dad63f29cc40e274340b335803e3ecfa440ff1b92329db73e934d146f2ca5e9d",

--- a/MODULE.bazel.tmpl
+++ b/MODULE.bazel.tmpl
@@ -28,18 +28,6 @@ bazel_dep(name = "googletest", version = "1.16.0.bcr.1", repo_name = "com_google
 
 bazel_dep(name = "abseil-cpp", version = "{{absl.meta.version}}", repo_name = "com_google_absl")
 
-bazel_dep(name = "cel-cpp", repo_name = "com_google_cel_cpp")
-
-archive_override(
-    module_name = "cel-cpp",
-    strip_prefix = "cel-cpp-{{cel_cpp.meta.version}}",
-    patches=[
-        "@protovalidate-cc//deps:patches/cel_cpp/0001-Fix-build-on-Windows-MSVC.patch",
-    ],
-    patch_args=["-p1"],
-    urls = [
-        "https://github.com/google/cel-cpp/archive/v{{cel_cpp.meta.version}}.tar.gz"
-    ]
-)
+bazel_dep(name = "cel-cpp", version = "{{cel_cpp.meta.version}}", repo_name = "com_google_cel_cpp")
 
 bazel_dep(name = "protovalidate", version = "{{protovalidate.meta.version}}", repo_name = "com_github_bufbuild_protovalidate")


### PR DESCRIPTION
Hurray, cel-cpp is now in the BCR as of a month ago. Let's get ourselves one step closer to the BCR by pulling from it. We don't need the Windows patch in Bazel since cel-cpp still doesn't work in Bazel on Windows anyways (maybe next release...)