### PR TITLE
Two more BCR fixes for v1.0.0-rc.2

### DIFF
--- a/.github/workflows/publish-to-bcr.yaml
+++ b/.github/workflows/publish-to-bcr.yaml
@@ -17,5 +17,6 @@ jobs:
     uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v0.2.1
     with:
       tag_name: ${{ github.ref_name }}
+      registry_fork: bufbuild/bazel-central-registry
     secrets:
       publish_token: ${{ secrets.BCR_PUBLISH_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -58,6 +58,7 @@ jobs:
     # Temporary workaround so we can create the release as a draft.
     # https://github.com/bazel-contrib/.github/pull/37
     uses: jchadwick-buf/bazel-contrib.github/.github/workflows/release_ruleset.yaml@0b9072bbf2142c18418820574625f5d9098c5dd3
+    needs: create-release-tag
     with:
       release_files: protovalidate-cc-*.tar.gz
       prerelease: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,6 @@ jobs:
         with:
           script: |
             const tag = '${{ github.event.inputs.tag_name }}';
-            const toolsTag = `tools/${tag}`;
             const commitTag = await github.rest.git.createTag({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -34,25 +33,11 @@ jobs:
               object: context.sha,
               type: 'commit',
             });
-            const toolsCommitTag = await github.rest.git.createTag({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              tag: toolsTag,
-              message: toolsTag,
-              object: context.sha,
-              type: 'commit',
-            });
             await github.rest.git.createRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
               ref: `refs/tags/${tag}`,
               sha: commitTag.data.sha,
-            });
-            await github.rest.git.createRef({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: `refs/tags/${toolsTag}`,
-              sha: toolsCommitTag.data.sha,
             });
   release:
     # Temporary workaround so we can create the release as a draft.


### PR DESCRIPTION
Like I said... sorry for the noise. :) (Will try to balance around different people to bug for these small PRs.)

I almost hit publish before realizing that I failed to specify the BCR fork to publish using in thepublish workflow inputs.

Also, fix a race condition by ensuring that the release job does not run prior to the create-release-tag job.