### PR TITLE
One more fix for BCR publish workflow

### DIFF
--- a/.github/workflows/publish-to-bcr.yaml
+++ b/.github/workflows/publish-to-bcr.yaml
@@ -10,6 +10,8 @@ on:
         required: true
 
 permissions:
+  id-token: write
+  attestations: write
   contents: write
 
 jobs:


### PR DESCRIPTION
Publish to BCR needs id-token + attestations.

Hopefully the last one?...