### PR TITLE
Fix e2e test by including source info

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,5 +1,7 @@
 common --enable_bzlmod --noenable_workspace
 
+build --experimental_proto_descriptor_sets_include_source_info
+
 build --cxxopt=-std=c++17 --host_cxxopt=-std=c++17
 build --cxxopt=-fsized-deallocation
 


### PR DESCRIPTION
Not urgent but looks like we'll need this to actually make the BCR release work all the way.