### PR TITLE
Fix Bazel WORKSPACE instructions in readme and release message

### DIFF
--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -63,7 +63,7 @@ http_archive(
     sha256 = "${SHA256}",
     strip_prefix = "${PREFIX}",
     urls = [
-        "https://github.com/bufbuild/protovalidate-cc/archive/${TAG}.tar.gz",
+        "https://github.com/bufbuild/protovalidate-cc/releases/download/${TAG}/protovalidate-cc-${TAG:1}.tar.gz",
     ],
 )
 \`\`\`

--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -63,7 +63,7 @@ http_archive(
     sha256 = "${SHA256}",
     strip_prefix = "${PREFIX}",
     urls = [
-        "https://github.com/bufbuild/protovalidate-cc/releases/download/${TAG}/protovalidate-cc-${TAG}.tar.gz",
+        "https://github.com/bufbuild/protovalidate-cc/archive/${TAG}.tar.gz",
     ],
 )
 \`\`\`

--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 http_archive(
     name = "com_github_bufbuild_protovalidate_cc",
     sha256 = ...,
-    strip_prefix = "protovalidate-cc-{verion}",
+    strip_prefix = "protovalidate-cc-{version}",
     urls = [
-        "https://github.com/bufbuild/protovalidate-cc/archive/v{verion}.tar.gz",
+        "https://github.com/bufbuild/protovalidate-cc/archive/v{version}.tar.gz",
     ],
 )
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ http_archive(
     sha256 = ...,
     strip_prefix = "protovalidate-cc-{version}",
     urls = [
-        "https://github.com/bufbuild/protovalidate-cc/archive/v{version}.tar.gz",
+        "https://github.com/bufbuild/protovalidate-cc/releases/download/${TAG}/protovalidate-cc-${TAG:1}.tar.gz",
     ],
 )
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ http_archive(
     sha256 = ...,
     strip_prefix = "protovalidate-cc-{version}",
     urls = [
-        "https://github.com/bufbuild/protovalidate-cc/releases/download/${TAG}/protovalidate-cc-${TAG:1}.tar.gz",
+        "https://github.com/bufbuild/protovalidate-cc/releases/download/v{version}/protovalidate-cc-{version}.tar.gz",
     ],
 )
 


### PR DESCRIPTION
For example,
https://github.com/bufbuild/protovalidate-cc/releases/tag/v1.0.0-rc.5 links to https://github.com/bufbuild/protovalidate-cc/releases/download/v1.0.0-rc.5/protovalidate-cc-v1.0.0-rc.5.tar.gz which 404s, but
https://github.com/bufbuild/protovalidate-cc/releases/download/v1.0.0-rc.5/protovalidate-cc-1.0.0-rc.5.tar.gz and
https://github.com/bufbuild/protovalidate-cc/archive/v1.0.0-rc.5.tar.gz are valid links.