### PR TITLE
Update count for new protobuf version

### DIFF
--- a/buf/validate/internal/message_rules.cc
+++ b/buf/validate/internal/message_rules.cc
@@ -81,7 +81,7 @@ Rules NewMessageRules(
       continue;
     }    
     auto fieldLvl = std::ref(field->options().GetExtension(buf::validate::field));
-    if (!fieldLvl.get().has_ignore() && allMsgOneofs.count(field->name()) > 0) {
+    if (!fieldLvl.get().has_ignore() && allMsgOneofs.count(std::string(field->name())) > 0) {
       auto* fieldLvlOvr = google::protobuf::Arena::Create<FieldRules>(arena);
       fieldLvlOvr->CopyFrom(fieldLvl);
       fieldLvlOvr->set_ignore(IGNORE_IF_UNPOPULATED);


### PR DESCRIPTION
Without this patch the following error occurs when compiling the CMake example:
```
/home/foxmoss/Projects/protovalidate-cc/buf/validate/internal/message_rules.cc: In function ‘buf::validate::internal::Rules buf::validate::internal::NewMessageRules(std::unique_ptr<MessageFactory>&, bool, google::protobuf::Arena*, google::api::expr::runtime::CelExpressionBuilder&, const google::protobuf::Descriptor*)’:
/home/foxmoss/Projects/protovalidate-cc/buf/validate/internal/message_rules.cc:84:59: error: no matching function for call to ‘std::unordered_set<std::__cxx11::basic_string<char> >::count(absl::lts_20250512::string_view)’
   84 |     if (!fieldLvl.get().has_ignore() && allMsgOneofs.count(field->name()) > 0) {
      |                                         ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
```

Unsure how to update the version in shared_deps.json as bumping "version" to 31.2 results in errors.