### PR TITLE
Use tagged BCR release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-    
+
       - name: Create tag
         uses: actions/github-script@v7
         with:
@@ -40,7 +40,7 @@ jobs:
               sha: commitTag.data.sha,
             });
   release:
-    uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@master
+    uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v7.2.3
     needs: create-release-tag
     with:
       release_files: protovalidate-cc-*.tar.gz


### PR DESCRIPTION
While waiting for the changes that allow the BCR release workflow to create a draft release instead of publishing the release immediately, I was using a branch reference to try to get SLSA to work. Unfortunately that doesn't work: the SLSA attestation won't be trusted unless we're using a tagged version of the workflow. At some point, a tag was created for the merged change, so we can move to it now. With any luck, this should allow the next release of protovalidate-cc to pass attestation.