### PR TITLE
Switch all workflows to use runs-on

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,10 +14,11 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-24.04, macos-latest]
+        os: [runs-on=${{ github.run_id }}/runner=buf-16cpu-linux-x64/disk=large, macos-latest]
     name: Unit tests
     runs-on: ${{ matrix.os }}
     steps:
+      - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # v2.0.3
       - name: Cache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -14,10 +14,11 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-24.04, macos-latest, windows-latest]
+        os: [runs-on=${{ github.run_id }}/runner=buf-1cpu-linux-x64, macos-latest, windows-latest]
     name: Unit tests
     runs-on: ${{ matrix.os }}
     steps:
+      - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # v2.0.3
       - name: Cache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -13,8 +13,9 @@ permissions:
 jobs:
   conformance:
     name: Conformance Testing
-    runs-on: ubuntu-24.04
+    runs-on: runs-on=${{ github.run_id }}/runner=buf-1cpu-linux-x64
     steps:
+      - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # v2.0.3
       - name: Setup Cache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/pr-hygiene.yaml
+++ b/.github/workflows/pr-hygiene.yaml
@@ -17,8 +17,9 @@ on:
 jobs:
   lint-title:
     name: Lint title
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=buf-1cpu-linux-x64
     steps:
+      - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # v2.0.3
       - name: Lint title
         uses: morrisoncole/pr-lint-action@v1.7.1
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,8 +15,9 @@ permissions:
 jobs:
   create-release-tag:
     name: Create release tag
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=buf-1cpu-linux-x64
     steps:
+      - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # v2.0.3
       - name: Checkout
         uses: actions/checkout@v4
 


### PR DESCRIPTION
The most important one is ci.yaml which is using 16 core runners, which should get the most benefits, but might as well change all the rest as well.