### PR TITLE
Disable draft BCR PRs

### DIFF
--- a/.github/workflows/publish-to-bcr.yaml
+++ b/.github/workflows/publish-to-bcr.yaml
@@ -18,6 +18,7 @@ jobs:
   publish:
     uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v1.1.0
     with:
+      draft: false
       tag_name: ${{ inputs.tag_name || github.ref_name }}
       registry_fork: bufbuild/bazel-central-registry
     secrets:


### PR DESCRIPTION
The publish to BCR workflow has gotten stuck consistently the past few releases because the PR is initially created as draft and later marked as ready once the bot picks up. The bot never marks them as ready. To avoid this, we skip creating a draft. This change follows a [recommendation](https://github.com/bazelbuild/bazel-central-registry/pull/7446?notification_referrer_id=NT_kwHOBY1nbNoAJVJlcG9zaXRvcnk7MzA3NzQ1MDg2O0lzc3VlOzM5MDY0NTQ2Nzk#issuecomment-3872187997) from BCR maintainers and protobuf's recent [switch](https://github.com/protocolbuffers/protobuf/commit/9db25c1fdfe737c00201873ef8afe4cd96d56661).