### PR TITLE
Update protovalidate to `v1.2.0`

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -33,4 +33,4 @@ bazel_dep(name = "abseil-cpp", version = "20240722.0", repo_name = "com_google_a
 
 bazel_dep(name = "cel-cpp", version = "0.11.0", repo_name = "com_google_cel_cpp")
 
-bazel_dep(name = "protovalidate", version = "1.1.1", repo_name = "com_github_bufbuild_protovalidate")
+bazel_dep(name = "protovalidate", version = "1.2.0", repo_name = "com_github_bufbuild_protovalidate")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -187,8 +187,8 @@
     "https://bcr.bazel.build/modules/protoc-gen-validate/1.0.4.bcr.2/MODULE.bazel": "c4bd2c850211ff5b7dadf9d2d0496c1c922fdedc303c775b01dfd3b3efc907ed",
     "https://bcr.bazel.build/modules/protoc-gen-validate/1.0.4.bcr.2/source.json": "4cc97f70b521890798058600a927ce4b0def8ee84ff2a5aa632aabcb4234aa0b",
     "https://bcr.bazel.build/modules/protoc-gen-validate/1.0.4/MODULE.bazel": "b8913c154b16177990f6126d2d2477d187f9ddc568e95ee3e2d50fc65d2c494a",
-    "https://bcr.bazel.build/modules/protovalidate/1.1.1/MODULE.bazel": "db32b8f0a17b23bf064e39a5cad9a6104eafb17ef19f6f38b06b44af5c5eca17",
-    "https://bcr.bazel.build/modules/protovalidate/1.1.1/source.json": "8dcc1dc3c83000b6db97926f61afa4c41a5179e3f9e91c7526f408ca89375c99",
+    "https://bcr.bazel.build/modules/protovalidate/1.2.0/MODULE.bazel": "8a85053d3348be53c1ff08e5e2e0189ca1040ec9ffa9d105f3450e7f0eb3db8d",
+    "https://bcr.bazel.build/modules/protovalidate/1.2.0/source.json": "46a6d27dda7a4878e4d65dbc0dbc24cb483212cdcccf11ee64f5d7192cee9ebf",
     "https://bcr.bazel.build/modules/pybind11_bazel/2.11.1/MODULE.bazel": "88af1c246226d87e65be78ed49ecd1e6f5e98648558c14ce99176da041dc378e",
     "https://bcr.bazel.build/modules/pybind11_bazel/2.12.0/MODULE.bazel": "e6f4c20442eaa7c90d7190d8dc539d0ab422f95c65a57cc59562170c58ae3d34",
     "https://bcr.bazel.build/modules/pybind11_bazel/2.12.0/source.json": "6900fdc8a9e95866b8c0d4ad4aba4d4236317b5c1cd04c502df3f0d33afed680",
@@ -482,7 +482,7 @@
     "@@rules_buf+//buf:extensions.bzl%buf": {
       "general": {
         "bzlTransitiveDigest": "i9geW3zp0Qwl17Z7qBERkLZ3uBUVLtepHhT6LeYXJ/g=",
-        "usagesDigest": "C8NsU43IXzYjVvo+4NII4dzvmOUUHtqyfVVz/AkSMms=",
+        "usagesDigest": "3/7DycSOwni3TRYjEyN5kvVxUuvyGSi2qLlgBDcjwU0=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},

--- a/buf/validate/validator_test.cc
+++ b/buf/validate/validator_test.cc
@@ -80,7 +80,7 @@ TEST(ValidatorTest, ValidateBool) {
   ASSERT_TRUE(violations_or.ok()) << violations_or.status();
   ASSERT_EQ(violations_or.value().violations_size(), 1);
   EXPECT_EQ(violations_or.value().violations(0).proto().rule_id(), "bool.const");
-  EXPECT_EQ(violations_or.value().violations(0).proto().message(), "value must equal false");
+  EXPECT_EQ(violations_or.value().violations(0).proto().message(), "must equal false");
 }
 
 TEST(ValidatorTest, ValidateStrRepeatedUniqueSuccess) {
@@ -141,7 +141,7 @@ TEST(ValidatorTest, ValidateRelativeURIFailure) {
   ASSERT_TRUE(violations_or.ok()) << violations_or.status();
   EXPECT_EQ(violations_or.value().violations_size(), 1);
   EXPECT_EQ(violations_or.value().violations(0).proto().rule_id(), "string.uri");
-  EXPECT_EQ(violations_or.value().violations(0).proto().message(), "value must be a valid URI");
+  EXPECT_EQ(violations_or.value().violations(0).proto().message(), "must be a valid URI");
   EXPECT_THAT(
       violations_or.value().violations(0).field_value(),
       Optional(FieldValueOf(VariantWith<std::string>("/foo/bar?baz=quux"))));
@@ -202,7 +202,7 @@ TEST(ValidatorTest, ValidateBadURIRefFailure) {
   EXPECT_EQ(violations_or.value().violations_size(), 1);
   EXPECT_EQ(violations_or.value().violations(0).proto().rule_id(), "string.uri_ref");
   EXPECT_EQ(
-      violations_or.value().violations(0).proto().message(), "value must be a valid URI Reference");
+      violations_or.value().violations(0).proto().message(), "must be a valid URI Reference");
   EXPECT_THAT(
       violations_or.value().violations(0).field_value(),
       Optional(FieldValueOf(VariantWith<std::string>("!@#$%^&*"))));
@@ -251,7 +251,7 @@ TEST(ValidatorTest, ValidateStringContainsFailure) {
   EXPECT_EQ(violations_or.value().violations(0).proto().rule_id(), "string.contains");
   EXPECT_EQ(
       violations_or.value().violations(0).proto().message(),
-      "value does not contain substring `bar`");
+      "does not contain substring `bar`");
 }
 
 TEST(ValidatorTest, ValidateStringContainsSuccess) {
@@ -279,7 +279,7 @@ TEST(ValidatorTest, ValidateBytesContainsFailure) {
   ASSERT_TRUE(violations_or.ok()) << violations_or.status();
   EXPECT_EQ(violations_or.value().violations_size(), 1);
   EXPECT_EQ(violations_or.value().violations(0).proto().rule_id(), "bytes.contains");
-  EXPECT_EQ(violations_or.value().violations(0).proto().message(), "value does not contain 626172");
+  EXPECT_EQ(violations_or.value().violations(0).proto().message(), "does not contain 626172");
 }
 
 TEST(ValidatorTest, ValidateBytesContainsSuccess) {
@@ -308,7 +308,7 @@ TEST(ValidatorTest, ValidateStartsWithFailure) {
   EXPECT_EQ(violations_or.value().violations_size(), 1);
   EXPECT_EQ(violations_or.value().violations(0).proto().rule_id(), "string.prefix");
   EXPECT_EQ(
-      violations_or.value().violations(0).proto().message(), "value does not have prefix `foo`");
+      violations_or.value().violations(0).proto().message(), "does not have prefix `foo`");
 }
 
 TEST(ValidatorTest, ValidateStartsWithSuccess) {
@@ -337,7 +337,7 @@ TEST(ValidatorTest, ValidateEndsWithFailure) {
   EXPECT_EQ(violations_or.value().violations_size(), 1);
   EXPECT_EQ(violations_or.value().violations(0).proto().rule_id(), "string.suffix");
   EXPECT_EQ(
-      violations_or.value().violations(0).proto().message(), "value does not have suffix `baz`");
+      violations_or.value().violations(0).proto().message(), "does not have suffix `baz`");
 }
 
 TEST(ValidatorTest, ValidateHostnameSuccess) {

--- a/deps/shared_deps.json
+++ b/deps/shared_deps.json
@@ -38,10 +38,10 @@
   },
   "protovalidate": {
     "meta": {
-      "version": "1.1.1"
+      "version": "1.2.0"
     },
     "source": {
-      "sha256": "297dba5cdc25fa478c597e53af6c4ccf330c826e566384774b5176c13c8d3bd8",
+      "sha256": "9aee9beede94edc62fa472a58c964741f11e1a0ab7472f12cfb98381c2f502fd",
       "strip_prefix": "protovalidate-{version}",
       "urls": [
         "https://github.com/bufbuild/protovalidate/releases/download/v{version}/protovalidate-{version}.tar.gz"


### PR DESCRIPTION
Update prototovalidate to `v1.2.0`. This version updated the messages to remove the `value` prefix.