### PR TITLE
Update copyright year

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,4 @@
-# Copyright 2023-2025 Buf Technologies, Inc.
+# Copyright 2023-2026 Buf Technologies, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2023-2025 Buf Technologies, Inc.
+   Copyright 2023-2026 Buf Technologies, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,4 +1,4 @@
-# Copyright 2023-2025 Buf Technologies, Inc.
+# Copyright 2023-2026 Buf Technologies, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/MODULE.bazel.tmpl
+++ b/MODULE.bazel.tmpl
@@ -1,4 +1,4 @@
-# Copyright 2023-2025 Buf Technologies, Inc.
+# Copyright 2023-2026 Buf Technologies, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ MAKEFLAGS += --no-print-directory
 BIN := .tmp/bin
 COPYRIGHT_YEARS := 2023-2026
 LICENSE_IGNORE := -e internal/testdata/ -e .github/ -e .bcr/ -e buf/validate/conformance/*.yaml -e e2e/bzlmod/*.yaml
-LICENSE_HEADER_VERSION := 1.69.0
+BUF_VERSION := 1.69.0
 PROTOVALIDATE_VERSION ?= v$(shell <./deps/shared_deps.json jq -j .protovalidate.meta.version)
 
 # Set to use a different compiler. For example, `GO=go1.18rc1 make test`.
@@ -57,19 +57,11 @@ generate-bzlmod: ## Generate MODULE.bazel file from template
 
 .PHONY: generate-license
 generate-license: $(BIN)/license-header ## Generate license headers for files
-	@# We want to operate on a list of modified and new files, excluding
-	@# deleted and ignored files. git-ls-files can't do this alone. comm -23 takes
-	@# two files and prints the union, dropping lines common to both (-3) and
-	@# those only in the second file (-2). We make one git-ls-files call for
-	@# the modified, cached, and new (--others) files, and a second for the
-	@# deleted files.
-	comm -23 \
-		<(git ls-files --cached --modified --others --no-empty-directory --exclude-standard | sort -u | grep -v $(LICENSE_IGNORE) ) \
-		<(git ls-files --deleted | sort -u) | \
-		xargs $(BIN)/license-header \
-			--license-type apache \
-			--copyright-holder "Buf Technologies, Inc." \
-			--year-range "$(COPYRIGHT_YEARS)"
+	$(BIN)/license-header \
+		--license-type apache \
+		--copyright-holder "Buf Technologies, Inc." \
+		--year-range "$(COPYRIGHT_YEARS)" \
+		$(LICENSE_IGNORE)
 
 .PHONY: checkgenerate
 checkgenerate: generate
@@ -79,10 +71,10 @@ $(BIN):
 	@mkdir -p $(BIN)
 
 $(BIN)/buf: $(BIN) Makefile
-	GOBIN=$(abspath $(@D)) $(GO) install github.com/bufbuild/buf/cmd/buf@latest
+	GOBIN=$(abspath $(@D)) $(GO) install github.com/bufbuild/buf/cmd/buf@v$(BUF_VERSION)
 
 $(BIN)/license-header: $(BIN) Makefile
 	GOBIN=$(abspath $(@D)) $(GO) install \
-		  github.com/bufbuild/buf/private/pkg/licenseheader/cmd/license-header@v$(LICENSE_HEADER_VERSION)
+		  github.com/bufbuild/buf/private/pkg/licenseheader/cmd/license-header@v$(BUF_VERSION)
 
 $(BIN)/protovalidate-conformance: $(BIN) Makefile

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,9 @@ MAKEFLAGS += --warn-undefined-variables
 MAKEFLAGS += --no-builtin-rules
 MAKEFLAGS += --no-print-directory
 BIN := .tmp/bin
-COPYRIGHT_YEARS := 2023-2025
-LICENSE_IGNORE := -e internal/testdata/ -e .github/ -e .bcr/ -e buf/validate/conformance -e e2e/bzlmod
-LICENSE_HEADER_VERSION := 04ed9c9179fc71d0dab7bf2919fcdc7b0bd9fe60
+COPYRIGHT_YEARS := 2023-2026
+LICENSE_IGNORE := -e internal/testdata/ -e .github/ -e .bcr/ -e buf/validate/conformance/*.yaml -e e2e/bzlmod/*.yaml
+LICENSE_HEADER_VERSION := 1.69.0
 PROTOVALIDATE_VERSION ?= v$(shell <./deps/shared_deps.json jq -j .protovalidate.meta.version)
 
 # Set to use a different compiler. For example, `GO=go1.18rc1 make test`.
@@ -83,6 +83,6 @@ $(BIN)/buf: $(BIN) Makefile
 
 $(BIN)/license-header: $(BIN) Makefile
 	GOBIN=$(abspath $(@D)) $(GO) install \
-		  github.com/bufbuild/buf/private/pkg/licenseheader/cmd/license-header@$(LICENSE_HEADER_VERSION)
+		  github.com/bufbuild/buf/private/pkg/licenseheader/cmd/license-header@v$(LICENSE_HEADER_VERSION)
 
 $(BIN)/protovalidate-conformance: $(BIN) Makefile

--- a/REPO.bazel
+++ b/REPO.bazel
@@ -1,4 +1,4 @@
-# Copyright 2023-2025 Buf Technologies, Inc.
+# Copyright 2023-2026 Buf Technologies, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/bazel/BUILD.bazel
+++ b/bazel/BUILD.bazel
@@ -1,4 +1,4 @@
-# Copyright 2023-2025 Buf Technologies, Inc.
+# Copyright 2023-2026 Buf Technologies, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -1,4 +1,4 @@
-# Copyright 2023-2025 Buf Technologies, Inc.
+# Copyright 2023-2026 Buf Technologies, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/bazel/json.bzl
+++ b/bazel/json.bzl
@@ -1,4 +1,4 @@
-# Copyright 2023-2025 Buf Technologies, Inc.
+# Copyright 2023-2026 Buf Technologies, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/buf/BUILD.bazel
+++ b/buf/BUILD.bazel
@@ -1,4 +1,4 @@
-# Copyright 2023-2025 Buf Technologies, Inc.
+# Copyright 2023-2026 Buf Technologies, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/buf/validate/BUILD.bazel
+++ b/buf/validate/BUILD.bazel
@@ -1,4 +1,4 @@
-# Copyright 2023-2025 Buf Technologies, Inc.
+# Copyright 2023-2026 Buf Technologies, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/buf/validate/conformance/BUILD.bazel
+++ b/buf/validate/conformance/BUILD.bazel
@@ -1,4 +1,4 @@
-# Copyright 2023-2025 Buf Technologies, Inc.
+# Copyright 2023-2026 Buf Technologies, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/buf/validate/conformance/runner.cc
+++ b/buf/validate/conformance/runner.cc
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 Buf Technologies, Inc.
+// Copyright 2023-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/buf/validate/conformance/runner.h
+++ b/buf/validate/conformance/runner.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 Buf Technologies, Inc.
+// Copyright 2023-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/buf/validate/conformance/runner_main.cc
+++ b/buf/validate/conformance/runner_main.cc
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 Buf Technologies, Inc.
+// Copyright 2023-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/buf/validate/conformance/runner_test.cc
+++ b/buf/validate/conformance/runner_test.cc
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 Buf Technologies, Inc.
+// Copyright 2023-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/buf/validate/internal/BUILD.bazel
+++ b/buf/validate/internal/BUILD.bazel
@@ -1,4 +1,4 @@
-# Copyright 2023-2025 Buf Technologies, Inc.
+# Copyright 2023-2026 Buf Technologies, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/buf/validate/internal/cel_rules.h
+++ b/buf/validate/internal/cel_rules.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 Buf Technologies, Inc.
+// Copyright 2023-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/buf/validate/internal/cel_validation_rules.cc
+++ b/buf/validate/internal/cel_validation_rules.cc
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 Buf Technologies, Inc.
+// Copyright 2023-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/buf/validate/internal/cel_validation_rules.h
+++ b/buf/validate/internal/cel_validation_rules.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 Buf Technologies, Inc.
+// Copyright 2023-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/buf/validate/internal/extra_func.cc
+++ b/buf/validate/internal/extra_func.cc
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 Buf Technologies, Inc.
+// Copyright 2023-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/buf/validate/internal/extra_func.h
+++ b/buf/validate/internal/extra_func.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 Buf Technologies, Inc.
+// Copyright 2023-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/buf/validate/internal/extra_func_test.cc
+++ b/buf/validate/internal/extra_func_test.cc
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 Buf Technologies, Inc.
+// Copyright 2023-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/buf/validate/internal/field_rules.cc
+++ b/buf/validate/internal/field_rules.cc
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 Buf Technologies, Inc.
+// Copyright 2023-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/buf/validate/internal/field_rules.h
+++ b/buf/validate/internal/field_rules.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 Buf Technologies, Inc.
+// Copyright 2023-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/buf/validate/internal/lib/BUILD.bazel
+++ b/buf/validate/internal/lib/BUILD.bazel
@@ -1,4 +1,4 @@
-# Copyright 2023-2025 Buf Technologies, Inc.
+# Copyright 2023-2026 Buf Technologies, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/buf/validate/internal/lib/ipv4.cc
+++ b/buf/validate/internal/lib/ipv4.cc
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 Buf Technologies, Inc.
+// Copyright 2023-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/buf/validate/internal/lib/ipv4.h
+++ b/buf/validate/internal/lib/ipv4.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 Buf Technologies, Inc.
+// Copyright 2023-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/buf/validate/internal/lib/ipv4_test.cc
+++ b/buf/validate/internal/lib/ipv4_test.cc
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 Buf Technologies, Inc.
+// Copyright 2023-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/buf/validate/internal/lib/ipv6.cc
+++ b/buf/validate/internal/lib/ipv6.cc
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 Buf Technologies, Inc.
+// Copyright 2023-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/buf/validate/internal/lib/ipv6.h
+++ b/buf/validate/internal/lib/ipv6.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 Buf Technologies, Inc.
+// Copyright 2023-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/buf/validate/internal/lib/ipv6_test.cc
+++ b/buf/validate/internal/lib/ipv6_test.cc
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 Buf Technologies, Inc.
+// Copyright 2023-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/buf/validate/internal/lib/parser_common.h
+++ b/buf/validate/internal/lib/parser_common.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 Buf Technologies, Inc.
+// Copyright 2023-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/buf/validate/internal/lib/uri.cc
+++ b/buf/validate/internal/lib/uri.cc
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 Buf Technologies, Inc.
+// Copyright 2023-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/buf/validate/internal/lib/uri.h
+++ b/buf/validate/internal/lib/uri.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 Buf Technologies, Inc.
+// Copyright 2023-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/buf/validate/internal/lib/uri_test.cc
+++ b/buf/validate/internal/lib/uri_test.cc
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 Buf Technologies, Inc.
+// Copyright 2023-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/buf/validate/internal/message_factory.cc
+++ b/buf/validate/internal/message_factory.cc
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 Buf Technologies, Inc.
+// Copyright 2023-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/buf/validate/internal/message_factory.h
+++ b/buf/validate/internal/message_factory.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 Buf Technologies, Inc.
+// Copyright 2023-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/buf/validate/internal/message_rules.cc
+++ b/buf/validate/internal/message_rules.cc
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 Buf Technologies, Inc.
+// Copyright 2023-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/buf/validate/internal/message_rules.h
+++ b/buf/validate/internal/message_rules.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 Buf Technologies, Inc.
+// Copyright 2023-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/buf/validate/internal/proto_field.h
+++ b/buf/validate/internal/proto_field.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 Buf Technologies, Inc.
+// Copyright 2023-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/buf/validate/internal/rules.cc
+++ b/buf/validate/internal/rules.cc
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 Buf Technologies, Inc.
+// Copyright 2023-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/buf/validate/internal/rules.h
+++ b/buf/validate/internal/rules.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 Buf Technologies, Inc.
+// Copyright 2023-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/buf/validate/internal/rules_test.cc
+++ b/buf/validate/internal/rules_test.cc
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 Buf Technologies, Inc.
+// Copyright 2023-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/buf/validate/internal/validation_rules.h
+++ b/buf/validate/internal/validation_rules.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 Buf Technologies, Inc.
+// Copyright 2023-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/buf/validate/validator.cc
+++ b/buf/validate/validator.cc
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 Buf Technologies, Inc.
+// Copyright 2023-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/buf/validate/validator.h
+++ b/buf/validate/validator.h
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 Buf Technologies, Inc.
+// Copyright 2023-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/buf/validate/validator_test.cc
+++ b/buf/validate/validator_test.cc
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 Buf Technologies, Inc.
+// Copyright 2023-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmake/example/example.proto
+++ b/cmake/example/example.proto
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 Buf Technologies, Inc.
+// Copyright 2023-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmake/example/main.cc
+++ b/cmake/example/main.cc
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 Buf Technologies, Inc.
+// Copyright 2023-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/deps/BUILD.bazel
+++ b/deps/BUILD.bazel
@@ -1,4 +1,4 @@
-# Copyright 2023-2025 Buf Technologies, Inc.
+# Copyright 2023-2026 Buf Technologies, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/bzlmod/BUILD.bazel
+++ b/e2e/bzlmod/BUILD.bazel
@@ -1,4 +1,4 @@
-# Copyright 2023-2025 Buf Technologies, Inc.
+# Copyright 2023-2026 Buf Technologies, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/bzlmod/MODULE.bazel
+++ b/e2e/bzlmod/MODULE.bazel
@@ -1,4 +1,4 @@
-# Copyright 2023-2025 Buf Technologies, Inc.
+# Copyright 2023-2026 Buf Technologies, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/bzlmod/example.proto
+++ b/e2e/bzlmod/example.proto
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 Buf Technologies, Inc.
+// Copyright 2023-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/e2e/bzlmod/main.cc
+++ b/e2e/bzlmod/main.cc
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 Buf Technologies, Inc.
+// Copyright 2023-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
- Fix Makefile to only exclude YAML files in conformance and bzlmod directories.
- The Makefile also uses the buf version (currently 1.69.0) to track the license header version, not the SHA of the commit.
