### PR TITLE
Fix segfault with empty bytes and matching of inner NULL

### DIFF
--- a/buf/validate/internal/extra_func.cc
+++ b/buf/validate/internal/extra_func.cc
@@ -145,7 +145,7 @@ cel::CelValue contains(
         arena, absl::StatusCode::kInvalidArgument, "does not contain the right value");
     return cel::CelValue::CreateError(error);
   }
-  bool result = absl::StrContains(lhs.value().data(), rhs.BytesOrDie().value());
+  bool result = absl::StrContains(lhs.value(), rhs.BytesOrDie().value());
   return cel::CelValue::CreateBool(result);
 }
 
@@ -156,7 +156,7 @@ cel::CelValue startsWith(
         arena, absl::StatusCode::kInvalidArgument, "doesnt start with the right thing");
     return cel::CelValue::CreateError(error);
   }
-  bool result = absl::StartsWith(lhs.value().data(), rhs.BytesOrDie().value());
+  bool result = absl::StartsWith(lhs.value(), rhs.BytesOrDie().value());
   return cel::CelValue::CreateBool(result);
 }
 
@@ -167,7 +167,7 @@ cel::CelValue endsWith(
         arena, absl::StatusCode::kInvalidArgument, "doesnt end with the right thing");
     return cel::CelValue::CreateError(error);
   }
-  bool result = absl::EndsWith(lhs.value().data(), rhs.BytesOrDie().value());
+  bool result = absl::EndsWith(lhs.value(), rhs.BytesOrDie().value());
   return cel::CelValue::CreateBool(result);
 }
 

--- a/buf/validate/validator_test.cc
+++ b/buf/validate/validator_test.cc
@@ -295,6 +295,61 @@ TEST(ValidatorTest, ValidateBytesContainsSuccess) {
   EXPECT_EQ(violations_or.value().violations_size(), 0);
 }
 
+TEST(ValidatorTest, ValidateBytesContainsEmpty) {
+  conformance::cases::BytesContains bytes_contains;
+  auto factory_or = ValidatorFactory::New();
+  ASSERT_TRUE(factory_or.ok()) << factory_or.status();
+  auto factory = std::move(factory_or).value();
+  google::protobuf::Arena arena;
+  auto validator = factory->NewValidator(&arena, false);
+  auto violations_or = validator.Validate(bytes_contains);
+  ASSERT_TRUE(violations_or.ok()) << violations_or.status();
+  EXPECT_EQ(violations_or.value().violations_size(), 1);
+  EXPECT_EQ(violations_or.value().violations(0).proto().rule_id(), "bytes.contains");
+  EXPECT_EQ(violations_or.value().violations(0).proto().message(), "does not contain 626172");
+}
+
+TEST(ValidatorTest, ValidateBytesPrefixEmpty) {
+  conformance::cases::BytesPrefix bytes_prefix;
+  auto factory_or = ValidatorFactory::New();
+  ASSERT_TRUE(factory_or.ok()) << factory_or.status();
+  auto factory = std::move(factory_or).value();
+  google::protobuf::Arena arena;
+  auto validator = factory->NewValidator(&arena, false);
+  auto violations_or = validator.Validate(bytes_prefix);
+  ASSERT_TRUE(violations_or.ok()) << violations_or.status();
+  EXPECT_EQ(violations_or.value().violations_size(), 1);
+  EXPECT_EQ(violations_or.value().violations(0).proto().rule_id(), "bytes.prefix");
+  EXPECT_EQ(violations_or.value().violations(0).proto().message(), "does not have prefix 99");
+}
+
+TEST(ValidatorTest, ValidateBytesSuffixEmpty) {
+  conformance::cases::BytesSuffix bytes_suffix;
+  auto factory_or = ValidatorFactory::New();
+  ASSERT_TRUE(factory_or.ok()) << factory_or.status();
+  auto factory = std::move(factory_or).value();
+  google::protobuf::Arena arena;
+  auto validator = factory->NewValidator(&arena, false);
+  auto violations_or = validator.Validate(bytes_suffix);
+  ASSERT_TRUE(violations_or.ok()) << violations_or.status();
+  EXPECT_EQ(violations_or.value().violations_size(), 1);
+  EXPECT_EQ(violations_or.value().violations(0).proto().rule_id(), "bytes.suffix");
+  EXPECT_EQ(violations_or.value().violations(0).proto().message(), "does not have suffix 62757a7a");
+}
+
+TEST(ValidatorTest, ValidateBytesContainsEmbeddedNul) {
+  conformance::cases::BytesContains bytes_contains;
+  bytes_contains.set_val(std::string("foo\0bar", 7));
+  auto factory_or = ValidatorFactory::New();
+  ASSERT_TRUE(factory_or.ok()) << factory_or.status();
+  auto factory = std::move(factory_or).value();
+  google::protobuf::Arena arena;
+  auto validator = factory->NewValidator(&arena, false);
+  auto violations_or = validator.Validate(bytes_contains);
+  ASSERT_TRUE(violations_or.ok()) << violations_or.status();
+  EXPECT_EQ(violations_or.value().violations_size(), 0);
+}
+
 TEST(ValidatorTest, ValidateStartsWithFailure) {
   conformance::cases::StringPrefix str_starts_with;
   str_starts_with.set_val("ffoobar");


### PR DESCRIPTION
Randomly ran into this when testing protovalidate-py (paused release on it). A `string_view` is a bytes without accessing the inner pointer, but the pointer will be NULL for an empty string which crashes cel-cpp when it tries to recover the string length with `strlen`.

Coincidentally, this fixes matching of bytes with a `NULL` inside which is where `strlen` would stop before this change.